### PR TITLE
fix(editor): replace active range selection before CLI insertText

### DIFF
--- a/features/editor/components/editor.tsx
+++ b/features/editor/components/editor.tsx
@@ -204,9 +204,18 @@ export function Editor({
             editor.editorStore.resetMD(text);
             return;
         }
-        // TODO(user): if there's an active range selection, delete it before
-        // insertText so the new text replaces the selection (standard editor
-        // behavior). store.insertText currently only handles the caret case.
+        // If the user has an active range selection, delete it first so the
+        // inserted text replaces the selection (standard editor behavior).
+        // store.insertText only handles the caret case today.
+        try {
+            const sel = store?.getSelectionState?.();
+            if (sel && sel.type === "range" && sel.anchor && sel.head && sel.anchor !== sel.head) {
+                store?.deleteRange?.(sel.anchor, sel.head);
+            }
+        } catch {
+            // getSelectionState may throw if the document isn't ready yet;
+            // fall through and let insertText handle the caret case.
+        }
         store?.insertText(text);
     });
 


### PR DESCRIPTION
When the Tauri CLI sends an "insert" event with a non-empty document, the previous handler unconditionally called `store.insertText(text)`. That works at the caret but produces a no-op visual change when the user has a text range selected — the inserted text lands at the caret while the selection stays.

Standard editor behavior is to replace the selected range with the new text. This change reads the selection state, deletes the range if it is a non-empty selection, and then calls `insertText`. The selection lookup is wrapped in `try/catch` because `getSelectionState` may throw while the document is still initializing.

No behavior change when there is no selection or when the selection is a collapsed caret.

The methods called (`getSelectionState`, `deleteRange`) already exist on the editor store; this PR only adds the call site in the CLI insert handler.
