### PR TITLE
feat(landing): read-first README with opt-in live editing

### DIFF
--- a/common/i18n/locales/en.json
+++ b/common/i18n/locales/en.json
@@ -24,7 +24,11 @@
     },
     "landing": {
         "copyright": "© {{year}} DOMD",
-        "tagline": "A clean place to write Markdown."
+        "tagline": "A clean place to write Markdown.",
+        "editPill": "Edit",
+        "editHint": "This page is a live editor — click anywhere and type. Nothing is saved.",
+        "editingChip": "Editing · not saved",
+        "exitEdit": "Exit editing"
     },
     "editor": {
         "placeholder": "Start writing Markdown...",

--- a/common/i18n/locales/ja.json
+++ b/common/i18n/locales/ja.json
@@ -24,7 +24,11 @@
     },
     "landing": {
         "copyright": "© {{year}} DOMD",
-        "tagline": "Markdown を書くための、すっきりとした場所。"
+        "tagline": "Markdown を書くための、すっきりとした場所。",
+        "editPill": "編集",
+        "editHint": "このページはライブエディタです — どこでもクリックして入力できます。保存はされません。",
+        "editingChip": "編集中 · 保存なし",
+        "exitEdit": "編集を終了"
     },
     "editor": {
         "placeholder": "Markdown を書き始める...",

--- a/common/i18n/locales/zh.json
+++ b/common/i18n/locales/zh.json
@@ -24,7 +24,11 @@
     },
     "landing": {
         "copyright": "© {{year}} DOMD",
-        "tagline": "一个纯粹的 Markdown 写作空间。"
+        "tagline": "一个纯粹的 Markdown 写作空间。",
+        "editPill": "编辑",
+        "editHint": "这是一个实时编辑器 —— 点击任意位置即可输入，内容不会保存。",
+        "editingChip": "编辑中 · 不保存",
+        "exitEdit": "退出编辑"
     },
     "editor": {
         "placeholder": "开始书写 Markdown……",

--- a/features/landing/components/readme-editor.tsx
+++ b/features/landing/components/readme-editor.tsx
@@ -5,8 +5,54 @@ import { DOMD, DOMDProvider } from "@do-md/core-react";
 import "@do-md/core-react/style.css";
 import { tokenize } from "@/common/lib/prism";
 import { pickByLocale } from "@/common/lib/locale";
-import { useEditorStoreApi } from "@do-md/core-react";
+import {
+    useEditorStoreApi,
+    useEditorDom,
+    type EditorStoreApi,
+} from "@do-md/core-react";
 import { CustomCursor } from "@/plugins/rendering/CustomCursor";
+
+// setEditable landed in @do-md/core-react 0.2.10 but isn't in the package's
+// hand-maintained d.ts yet. Augment the exported store type so we can toggle
+// editability in place instead of remounting a fresh provider.
+declare module "@do-md/core-react" {
+    interface EditorStoreApi {
+        setEditable(editable: boolean): void;
+    }
+}
+
+// Bridges the in-provider editor store out to a parent ref so the overlay
+// controls (which live outside the provider) can call setEditable.
+function StoreBridge({
+    apiRef,
+}: {
+    apiRef: React.MutableRefObject<EditorStoreApi | null>;
+}) {
+    const store = useEditorStoreApi();
+    useEffect(() => {
+        apiRef.current = store;
+        return () => {
+            apiRef.current = null;
+        };
+    }, [store, apiRef]);
+    return null;
+}
+
+// Streaming pacing. The point of the stream is the "AI typing" flourish — but
+// only the part the reader can actually see is worth pacing. So the visible
+// first screen types at a readable cruise speed; the moment the content grows
+// past the fold (further chunks land off-screen), we ramp up — each chunk gets
+// bigger and its delay shorter — so the invisible remainder finishes fast and
+// the reader can start editing sooner.
+const CRUISE_CHUNK_MIN = 50; // chars per chunk while visible
+const CRUISE_CHUNK_MAX = 64;
+const CRUISE_DELAY_MIN = 55; // ms between chunks while visible
+const CRUISE_DELAY_MAX = 85;
+const ACCEL_GROWTH = 1.5; // per off-screen chunk: size ×, delay ÷
+const ACCEL_MAX_CHUNK = 4000; // cap so a single insert can't get pathological
+// Safety net: if the editor DOM can't be measured, ramp up after this many
+// chars anyway so a tall/oddly-laid-out viewport never streams slowly forever.
+const FALLBACK_ACCEL_AT = 2000;
 
 // Streams `text` into the surrounding DOMDProvider one chunk at a time,
 // mimicking an AI token stream. Must sit inside the provider so `useEditor`
@@ -21,6 +67,7 @@ function StreamDriver({
     onDone: () => void;
 }) {
     const editorStore = useEditorStoreApi();
+    const { textAreaDomRef } = useEditorDom();
     const onDoneRef = useRef(onDone);
 
     useEffect(() => {
@@ -29,7 +76,18 @@ function StreamDriver({
 
         const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
         const rand = (a: number, b: number) => a + Math.random() * (b - a);
+        const randInt = (a: number, b: number) =>
+            a + Math.floor(Math.random() * (b - a + 1));
         const aborted = () => cancelled || abortRef.current;
+
+        // True once the streamed content has filled the viewport, i.e. new
+        // chunks now land below the fold where the stream isn't visible.
+        const pastFold = () => {
+            if (typeof window === "undefined") return false;
+            const el = textAreaDomRef.current;
+            if (!el) return false;
+            return el.getBoundingClientRect().bottom >= window.innerHeight;
+        };
 
         (async () => {
             if (aborted()) return;
@@ -40,23 +98,45 @@ function StreamDriver({
             editorStore.resetMD(text.slice(0, firstSize));
             let i = firstSize;
 
+            // `accel` grows geometrically once we cross the fold, so both the
+            // chunk size and the (shrinking) delay compound — faster and faster.
+            let accelerating = false;
+            let accel = 1;
+
             while (i < text.length) {
                 if (aborted()) return;
-                // Split the inter-chunk wait into ~10ms slices so a tap can
-                // halt insertions within one slice. A single 60–90ms sleep
-                // would let one more insertText slip through after abort and
-                // mutate the DOM during the pointerdown→click window, which
-                // iOS reads as instability and cancels the click.
-                const target = rand(55, 85);
+
+                if (!accelerating && (i >= FALLBACK_ACCEL_AT || pastFold())) {
+                    accelerating = true;
+                }
+
+                let size: number;
+                let delay: number;
+                if (accelerating) {
+                    size = Math.min(
+                        Math.round(CRUISE_CHUNK_MAX * accel),
+                        ACCEL_MAX_CHUNK,
+                    );
+                    delay = CRUISE_DELAY_MIN / accel;
+                    accel *= ACCEL_GROWTH;
+                } else {
+                    size = randInt(CRUISE_CHUNK_MIN, CRUISE_CHUNK_MAX);
+                    delay = rand(CRUISE_DELAY_MIN, CRUISE_DELAY_MAX);
+                }
+
+                // Split the wait into ~10ms slices so a tap can halt insertions
+                // within one slice. A single long sleep would let one more
+                // insertText slip through after abort and mutate the DOM during
+                // the pointerdown→click window, which iOS reads as instability
+                // and cancels the click.
                 let waited = 0;
-                while (waited < target) {
+                while (waited < delay) {
                     if (aborted()) return;
-                    const step = Math.min(target - waited, 10);
+                    const step = Math.min(delay - waited, 10);
                     await sleep(step);
                     waited += step;
                 }
                 if (aborted()) return;
-                const size = 50 + Math.floor(Math.random() * 15); // 50..64
                 editorStore.insertText(text.slice(i, i + size));
                 i += size;
             }
@@ -71,7 +151,7 @@ function StreamDriver({
         return () => {
             cancelled = true;
         };
-    }, [editorStore, text, abortRef]);
+    }, [editorStore, text, abortRef, textAreaDomRef]);
 
     return null;
 }
@@ -146,26 +226,24 @@ export function ReadmeEditor({ streams }: { streams: ReadmeStreams }) {
     //  streaming still works). When it finishes, the page just sits there as a
     //  clean reading surface — no caret, text selectable, links clickable.
     //
-    //  A corner pill invites the reader to opt into editing. Clicking it
-    //  remounts the editor as editable (the `editable` prop is init-only, so a
-    //  fresh instance keyed "edit" is the only way to flip it) seeded with the
-    //  same streamed markdown, and shows a "nothing is saved" reassurance. The
-    //  edit chip carries an × to leave — which drops back to a *static* read
-    //  instance (seeded, no StreamDriver) so exiting never re-runs the stream.
+    //  A corner pill invites the reader to opt into editing. It calls the
+    //  store's setEditable(true) to flip the SAME instance editable in place —
+    //  no remount, no re-seed, and any edits persist when toggling back. The
+    //  edit chip carries an × that calls setEditable(false) to return to
+    //  reading. A "nothing is saved" toast reassures on entry.
     const { t } = useTranslation();
     const [phase, setPhase] = useState<Phase>("ssr");
     const [streamText, setStreamText] = useState<string | null>(null);
     const [streamingDone, setStreamingDone] = useState(false);
     const [editMode, setEditMode] = useState(false);
-    // True once the reader has entered edit mode at least once. After that,
-    // read mode renders the seeded static instance instead of re-streaming.
-    const [streamedOnce, setStreamedOnce] = useState(false);
     const [showToast, setShowToast] = useState(false);
     // Synchronous abort signal for the streaming loop. We flip this in the
     // pointerdown handler without calling setState, so no React render runs
     // between pointerdown and the synthesized click — iOS cancels the click
     // if the DOM mutates in that window.
     const abortRef = useRef(false);
+    // Live editor store, lifted out of the provider by StoreBridge.
+    const storeRef = useRef<EditorStoreApi | null>(null);
 
     useEffect(() => {
         const text = pickStream(streams);
@@ -208,12 +286,13 @@ export function ReadmeEditor({ streams }: { streams: ReadmeStreams }) {
     const canEdit = streamText !== null && streamingDone && !editMode;
 
     const enterEdit = () => {
+        storeRef.current?.setEditable(true);
         setEditMode(true);
-        setStreamedOnce(true);
         setShowToast(true);
     };
 
     const exitEdit = () => {
+        storeRef.current?.setEditable(false);
         setEditMode(false);
         setShowToast(false);
     };
@@ -238,47 +317,25 @@ export function ReadmeEditor({ streams }: { streams: ReadmeStreams }) {
                     >
                         <DOMD />
                     </DOMDProvider>
-                ) : !editMode && !streamedOnce ? (
-                    // Live read mode: streams into a non-editable editor, then
-                    // rests as a clean reading surface (no caret, selectable,
-                    // links live). Stays mounted after the stream finishes.
+                ) : (
+                    // One persistent instance for the whole client lifetime:
+                    // starts read-only, streams in, then setEditable() toggles
+                    // it between reading and editing in place. CustomCursor only
+                    // mounts while editing (custom caret is meaningless in read).
                     <DOMDProvider
-                        key="read-stream"
+                        key="client"
                         editable={false}
                         initMd=""
                         codeTokenizer={tokenize}
                     >
                         <DOMD />
+                        <StoreBridge apiRef={storeRef} />
                         <StreamDriver
                             text={streamText}
                             abortRef={abortRef}
                             onDone={() => setStreamingDone(true)}
                         />
-                    </DOMDProvider>
-                ) : !editMode ? (
-                    // Static read mode: entered only after an edit session.
-                    // Seeded with the full markdown, no StreamDriver — leaving
-                    // edit mode must never replay the stream.
-                    <DOMDProvider
-                        key="read-static"
-                        editable={false}
-                        initMd={streamText}
-                        codeTokenizer={tokenize}
-                    >
-                        <DOMD />
-                    </DOMDProvider>
-                ) : (
-                    // Edit mode: fresh editable instance seeded with the same
-                    // markdown. Keyed distinctly to force a remount (editable is
-                    // read once at construction).
-                    <DOMDProvider
-                        key="edit"
-                        editable={true}
-                        initMd={streamText}
-                        codeTokenizer={tokenize}
-                    >
-                        <DOMD />
-                        <CustomCursor />
+                        {editMode && <CustomCursor />}
                     </DOMDProvider>
                 )}
             </div>

--- a/features/landing/components/readme-editor.tsx
+++ b/features/landing/components/readme-editor.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { DOMD, DOMDProvider } from "@do-md/core-react";
 import "@do-md/core-react/style.css";
 import { tokenize } from "@/common/lib/prism";
@@ -33,8 +34,8 @@ function StreamDriver({
         (async () => {
             if (aborted()) return;
             // Seed: empty doc has no cursor, so plain insertText would be a
-            // no-op. resetMD parses an initial slice, then focus() puts the
-            // caret at end-of-doc so aiInsertInCursor has somewhere to land.
+            // no-op. resetMD parses an initial slice so subsequent insertText
+            // calls have a last block to append to.
             const firstSize = 180 + Math.floor(Math.random() * 60); // 180..239
             editorStore.resetMD(text.slice(0, firstSize));
             let i = firstSize;
@@ -89,20 +90,77 @@ const FADE_MS = 350; // duration of the fade-out / fade-in halves
 // blockInput off. iOS dispatches click ~50–300ms after pointerdown; mutating
 // the DOM inside that window will cancel the click.
 const ABORT_RERENDER_DELAY_MS = 400;
+// How long the "nothing is saved" reassurance toast stays up after the reader
+// opts into edit mode.
+const TOAST_MS = 4200;
 
 type Phase = "ssr" | "fading" | "streaming";
 
+function PencilIcon() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+        >
+            <path d="M12 20h9" />
+            <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
+        </svg>
+    );
+}
+
+function XIcon() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+        >
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+        </svg>
+    );
+}
+
 export function ReadmeEditor({ streams }: { streams: ReadmeStreams }) {
-    // SSR + first-client render: English README (canonical, SEO-friendly).
+    // The landing surface has two jobs that fight on one plane: *reading* the
+    // README (the default — instant, passive, no caret) and *showing off* the
+    // editor (a deliberate flourish). We separate them by default-mode:
     //
-    // Then a small choreographed transition: hold the SSR'd content briefly
-    // so users perceive it, fade it out, swap to the empty interactive
-    // editor, fade that back in, then start streaming the locale-matched
-    // translation in AI-typing style. Streaming is locked via pointer-events
-    // until it finishes; after that the editor unlocks for normal use.
+    //  ssr → fading → streaming: the locale README types itself in AI style
+    //  into a READ-ONLY editor (editable=false; insertText is programmatic so
+    //  streaming still works). When it finishes, the page just sits there as a
+    //  clean reading surface — no caret, text selectable, links clickable.
+    //
+    //  A corner pill invites the reader to opt into editing. Clicking it
+    //  remounts the editor as editable (the `editable` prop is init-only, so a
+    //  fresh instance keyed "edit" is the only way to flip it) seeded with the
+    //  same streamed markdown, and shows a "nothing is saved" reassurance. The
+    //  edit chip carries an × to leave — which drops back to a *static* read
+    //  instance (seeded, no StreamDriver) so exiting never re-runs the stream.
+    const { t } = useTranslation();
     const [phase, setPhase] = useState<Phase>("ssr");
     const [streamText, setStreamText] = useState<string | null>(null);
     const [streamingDone, setStreamingDone] = useState(false);
+    const [editMode, setEditMode] = useState(false);
+    // True once the reader has entered edit mode at least once. After that,
+    // read mode renders the seeded static instance instead of re-streaming.
+    const [streamedOnce, setStreamedOnce] = useState(false);
+    const [showToast, setShowToast] = useState(false);
     // Synchronous abort signal for the streaming loop. We flip this in the
     // pointerdown handler without calling setState, so no React render runs
     // between pointerdown and the synthesized click — iOS cancels the click
@@ -139,43 +197,129 @@ export function ReadmeEditor({ streams }: { streams: ReadmeStreams }) {
             document.removeEventListener("pointerdown", onPointerDown, true);
     }, [phase, streamingDone]);
 
+    // Auto-dismiss the reassurance toast a few seconds after entering edit mode.
+    useEffect(() => {
+        if (!showToast) return;
+        const id = setTimeout(() => setShowToast(false), TOAST_MS);
+        return () => clearTimeout(id);
+    }, [showToast]);
+
     const blockInput = phase === "streaming" && !streamingDone;
+    const canEdit = streamText !== null && streamingDone && !editMode;
+
+    const enterEdit = () => {
+        setEditMode(true);
+        setStreamedOnce(true);
+        setShowToast(true);
+    };
+
+    const exitEdit = () => {
+        setEditMode(false);
+        setShowToast(false);
+    };
 
     return (
-        <div
-            suppressHydrationWarning
-            style={{
-                opacity: phase === "fading" ? 0 : 1,
-                transition: `opacity ${FADE_MS}ms ease`,
-                ...(blockInput
-                    ? { pointerEvents: "none", userSelect: "none" }
-                    : null),
-            }}
-        >
-            {streamText === null ? (
-                <DOMDProvider
-                    editable={false}
-                    initMd={streams.en}
-                    codeTokenizer={tokenize}
+        <>
+            <div
+                suppressHydrationWarning
+                style={{
+                    opacity: phase === "fading" ? 0 : 1,
+                    transition: `opacity ${FADE_MS}ms ease`,
+                    ...(blockInput
+                        ? { pointerEvents: "none", userSelect: "none" }
+                        : null),
+                }}
+            >
+                {streamText === null ? (
+                    <DOMDProvider
+                        editable={false}
+                        initMd={streams.en}
+                        codeTokenizer={tokenize}
+                    >
+                        <DOMD />
+                    </DOMDProvider>
+                ) : !editMode && !streamedOnce ? (
+                    // Live read mode: streams into a non-editable editor, then
+                    // rests as a clean reading surface (no caret, selectable,
+                    // links live). Stays mounted after the stream finishes.
+                    <DOMDProvider
+                        key="read-stream"
+                        editable={false}
+                        initMd=""
+                        codeTokenizer={tokenize}
+                    >
+                        <DOMD />
+                        <StreamDriver
+                            text={streamText}
+                            abortRef={abortRef}
+                            onDone={() => setStreamingDone(true)}
+                        />
+                    </DOMDProvider>
+                ) : !editMode ? (
+                    // Static read mode: entered only after an edit session.
+                    // Seeded with the full markdown, no StreamDriver — leaving
+                    // edit mode must never replay the stream.
+                    <DOMDProvider
+                        key="read-static"
+                        editable={false}
+                        initMd={streamText}
+                        codeTokenizer={tokenize}
+                    >
+                        <DOMD />
+                    </DOMDProvider>
+                ) : (
+                    // Edit mode: fresh editable instance seeded with the same
+                    // markdown. Keyed distinctly to force a remount (editable is
+                    // read once at construction).
+                    <DOMDProvider
+                        key="edit"
+                        editable={true}
+                        initMd={streamText}
+                        codeTokenizer={tokenize}
+                    >
+                        <DOMD />
+                        <CustomCursor />
+                    </DOMDProvider>
+                )}
+            </div>
+
+            {canEdit && (
+                <button
+                    type="button"
+                    onClick={enterEdit}
+                    title={t("landing.editHint")}
+                    aria-label={t("landing.editHint")}
+                    className="btn btn-accent btn-sm gap-2 rounded-full shadow-lg fixed bottom-6 right-6 z-40"
                 >
-                    <DOMD />
-                </DOMDProvider>
-            ) : (
-                <DOMDProvider
-                    key="client"
-                    editable={true}
-                    initMd=""
-                    codeTokenizer={tokenize}
-                >
-                    <DOMD />
-                    <CustomCursor />
-                    <StreamDriver
-                        text={streamText}
-                        abortRef={abortRef}
-                        onDone={() => setStreamingDone(true)}
-                    />
-                </DOMDProvider>
+                    <PencilIcon />
+                    {t("landing.editPill")}
+                </button>
             )}
-        </div>
+
+            {editMode && (
+                <div className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full bg-base-200/90 py-1.5 pl-3 pr-1.5 text-xs text-base-content/70 shadow-sm backdrop-blur">
+                    <span className="inline-block h-2 w-2 rounded-full bg-accent animate-pulse" />
+                    {t("landing.editingChip")}
+                    <button
+                        type="button"
+                        onClick={exitEdit}
+                        aria-label={t("landing.exitEdit")}
+                        title={t("landing.exitEdit")}
+                        className="btn btn-ghost btn-xs btn-circle -mr-0.5"
+                    >
+                        <XIcon />
+                    </button>
+                </div>
+            )}
+
+            {showToast && (
+                <div
+                    role="status"
+                    className="fixed bottom-20 right-6 z-40 max-w-xs rounded-lg bg-neutral px-4 py-3 text-sm text-neutral-content shadow-lg"
+                >
+                    {t("landing.editHint")}
+                </div>
+            )}
+        </>
     );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.2.7",
             "license": "MIT",
             "dependencies": {
-                "@do-md/core-react": "^0.2.9",
+                "@do-md/core-react": "^0.2.10",
                 "@tauri-apps/api": "^2.10.1",
                 "@tauri-apps/plugin-deep-link": "^2.4.8",
                 "@tauri-apps/plugin-dialog": "^2.7.0",
@@ -342,9 +342,9 @@
             }
         },
         "node_modules/@do-md/core-react": {
-            "version": "0.2.9",
-            "resolved": "https://registry.npmjs.org/@do-md/core-react/-/core-react-0.2.9.tgz",
-            "integrity": "sha512-s3Ir4FUV+KZbzAo2fXuhrQptGcD+tAprCVwZCmRbaSALr0G0E7M0tPX37PV+7YAAYB9iwqecnZyXop7vNGgGuw==",
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/@do-md/core-react/-/core-react-0.2.10.tgz",
+            "integrity": "sha512-tTI1fVTe0ey2WkvHM0kyVZSAiYLOpL3x2P+1k0QnzjMRRPMaEm3E/Y3PpqB2HJKkiY6guXLvDqkeeMZZ68UDFg==",
             "license": "PolyForm-Noncommercial-1.0.0"
         },
         "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "lint": "eslint"
     },
     "dependencies": {
-        "@do-md/core-react": "^0.2.9",
+        "@do-md/core-react": "^0.2.10",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-deep-link": "^2.4.8",
         "@tauri-apps/plugin-dialog": "^2.7.0",


### PR DESCRIPTION
## What

Reworks the landing README so it reads first and lets visitors opt into editing, instead of streaming the whole doc and then flipping the entire surface editable (which mixed "reading" and "editing" on one plane).

## Behaviour

- The locale README streams into a **read-only** editor, then rests as a clean reading surface — no caret, text selectable, links clickable.
- A corner **accent pill** invites the reader into edit mode; a one-time "nothing is saved" toast reassures on entry, and the editing chip carries an **×** to return to reading.
- Streaming is **adaptive**: the visible first screen types at a readable "AI typing" cruise speed; once content grows past the fold, each chunk grows (×1.5, capped) and its delay shrinks (÷1.5), so the off-screen remainder lands fast and the reader can start editing sooner. The fold is detected by measuring the editor's rendered height against the viewport, with a char-count fallback.

## Implementation notes

- One persistent editor instance for the whole client lifetime. Editability is toggled in place via the store's `setEditable()` (added in `@do-md/core-react` 0.2.10) — no remounting, and edits persist across read/edit toggles.
- `insertText` isn't gated by `isEditable`, so programmatic streaming works while the editor is read-only.
- `setEditable` isn't in the package's hand-maintained `d.ts` yet, so it's typed via a local module augmentation; a small `StoreBridge` lifts the store to a parent ref for the overlay controls.
- Adds `landing.editPill` / `editHint` / `editingChip` / `exitEdit` strings in en / zh / ja.

## Commits

- `feat(landing): read-first README with opt-in edit pill`
- `refactor(landing): in-place editable toggle + adaptive streaming pace`

## Test plan

- [x] First screen streams at the readable cruise pace; off-screen remainder accelerates and the full doc renders to the end without truncation.
- [x] Pill appears once streaming completes; clicking it makes the editor editable in place (verified by typing).
- [x] × returns to read-only (typing no longer inserts); prior edits persist across the toggle.
- [x] `eslint` and `tsc --noEmit` pass.