### PR TITLE
feat(editor): mobile quick-input bar, code-block cursor fix, table borders

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,17 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/next";
 import { I18nProvider } from "@/common/i18n/provider";
 import "./globals.css";
 import "./prism-themes.css";
 
 const SITE_URL = "https://www.domd.app";
+
+// viewport-fit=cover is required for env(safe-area-inset-*) to be non-zero
+// on notched iPhones — the mobile quick-input bar pads itself above the
+// home indicator with it.
+export const viewport: Viewport = {
+    viewportFit: "cover",
+};
 
 export const metadata: Metadata = {
     metadataBase: new URL(SITE_URL),

--- a/features/editor/components/editor.tsx
+++ b/features/editor/components/editor.tsx
@@ -25,6 +25,8 @@ import { useTauriEvent } from "../hooks/use-tauri-event";
 import { saveDocument } from "../lib/save-document";
 import type { FileMeta } from "../lib/types";
 import { CustomCursor } from "@/plugins/rendering/CustomCursor";
+import { QuickInputBar } from "@/plugins/toolbar/quick-input-bar";
+import { useVisualViewportPin } from "@/plugins/shared/use-visual-viewport-pin";
 
 export function Editor({
     meta,
@@ -47,6 +49,35 @@ export function Editor({
 
     const metaRef = useLatest(meta);
     const domdRef = useRef<HTMLDivElement>(null);
+    const scrollAreaRef = useRef<HTMLDivElement>(null);
+
+    // Software-keyboard geometry (iOS/Android). Non-null while the keyboard
+    // is up; the inner layer below pins to it so the quick-input bar sits
+    // exactly on the keyboard's top edge. Null on desktop -> static layout.
+    const keyboardPin = useVisualViewportPin();
+
+    // The keyboard shrinks the content area drastically — whenever the
+    // pinned geometry changes, scroll the caret back into the visible
+    // region. Scroll the INTERNAL container only; scrolling the layout
+    // viewport on iOS introduces offsetTop drift.
+    useEffect(() => {
+        if (!keyboardPin) return;
+        const container = scrollAreaRef.current;
+        if (!container) return;
+        const sel = document.getSelection();
+        if (!sel || sel.rangeCount === 0) return;
+        if (!container.contains(sel.anchorNode)) return;
+        const rect = sel.getRangeAt(0).getBoundingClientRect();
+        // A collapsed caret can report a zero rect (see CustomCursor); skip
+        // rather than scroll to a bogus position.
+        if (rect.width === 0 && rect.height === 0) return;
+        const box = container.getBoundingClientRect();
+        if (rect.bottom > box.bottom - 8) {
+            container.scrollBy({ top: rect.bottom - (box.bottom - 8) + 24 });
+        } else if (rect.top < box.top + 8) {
+            container.scrollBy({ top: rect.top - (box.top + 8) - 24 });
+        }
+    }, [keyboardPin]);
 
     // Auto-focus once when the editor instance materializes. @do-md hands the
     // editor back via a deferred setTimeout in its provider, so the first
@@ -338,39 +369,66 @@ export function Editor({
     const showSaveBar = meta.kind === "web";
 
     return (
-        <div className="fixed inset-0 flex flex-col bg-base-100 overflow-hidden">
-            {showSaveBar ? (
-                <div className="shrink-0 h-9 flex items-center gap-2 px-3 text-xs text-base-content/50 bg-base-200 border-b border-base-300 select-none">
-                    <span className="truncate flex-1">{meta.name}</span>
-                    <button
-                        onClick={onRequestOpenUrl}
-                        className="btn btn-xs btn-ghost"
-                    >
-                        {t("editor.openUrl")}
-                    </button>
-                    <button
-                        onClick={() => doSave(renderData)}
-                        disabled={saving}
-                        className="btn btn-xs btn-neutral"
-                    >
-                        {saving ? t("editor.saving") : saved ? t("editor.saved") : t("editor.save")}
-                    </button>
-                </div>
-            ) : null}
-
+        // Two layers (see plugins/shared/use-visual-viewport-pin.ts): the
+        // outer one stays fullscreen and opaque (iOS can pan the layout
+        // viewport while the keyboard is up — whatever peeks through must be
+        // ourselves); the inner one pins to the visual viewport so the
+        // quick-input bar rides the keyboard's top edge. --kb-safe-bottom
+        // zeroes the safe-area padding while the keyboard covers the home
+        // indicator.
+        <div className="fixed inset-0 bg-base-100 overflow-hidden">
             <div
-                className="flex-1 overflow-y-auto"
-                onClick={(e) => {
-                    if (domdRef.current?.contains(e.target as Node)) return;
-                    editor?.focus();
-                }}
+                className="absolute inset-x-0 flex flex-col"
+                style={
+                    keyboardPin
+                        ? ({
+                              top: keyboardPin.top,
+                              height: keyboardPin.height,
+                              "--kb-safe-bottom": "0px",
+                          } as React.CSSProperties)
+                        : { top: 0, height: "100%" }
+                }
             >
-                <div className="max-w-3xl mx-auto px-6 py-8">
-                    <div ref={domdRef}>
-                        <DOMD />
-                        {isEditable &&  <CustomCursor />}
+                {showSaveBar ? (
+                    <div className="shrink-0 h-9 flex items-center gap-2 px-3 text-xs text-base-content/50 bg-base-200 border-b border-base-300 select-none">
+                        <span className="truncate flex-1">{meta.name}</span>
+                        <button
+                            onClick={onRequestOpenUrl}
+                            className="btn btn-xs btn-ghost"
+                        >
+                            {t("editor.openUrl")}
+                        </button>
+                        <button
+                            onClick={() => doSave(renderData)}
+                            disabled={saving}
+                            className="btn btn-xs btn-neutral"
+                        >
+                            {saving
+                                ? t("editor.saving")
+                                : saved
+                                  ? t("editor.saved")
+                                  : t("editor.save")}
+                        </button>
+                    </div>
+                ) : null}
+
+                <div
+                    ref={scrollAreaRef}
+                    className="flex-1 min-h-0 overflow-y-auto"
+                    onClick={(e) => {
+                        if (domdRef.current?.contains(e.target as Node)) return;
+                        editor?.focus();
+                    }}
+                >
+                    <div className="max-w-3xl mx-auto px-6 py-8">
+                        <div ref={domdRef}>
+                            <DOMD />
+                            {isEditable && <CustomCursor />}
+                        </div>
                     </div>
                 </div>
+
+                <QuickInputBar pin={keyboardPin} />
             </div>
         </div>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "domd",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "domd",
-            "version": "0.2.7",
+            "version": "0.2.8",
             "license": "MIT",
             "dependencies": {
-                "@do-md/core-react": "^0.2.10",
+                "@do-md/core-react": "^0.2.11",
                 "@tauri-apps/api": "^2.10.1",
                 "@tauri-apps/plugin-deep-link": "^2.4.8",
                 "@tauri-apps/plugin-dialog": "^2.7.0",
@@ -342,9 +342,9 @@
             }
         },
         "node_modules/@do-md/core-react": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/@do-md/core-react/-/core-react-0.2.10.tgz",
-            "integrity": "sha512-tTI1fVTe0ey2WkvHM0kyVZSAiYLOpL3x2P+1k0QnzjMRRPMaEm3E/Y3PpqB2HJKkiY6guXLvDqkeeMZZ68UDFg==",
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@do-md/core-react/-/core-react-0.2.11.tgz",
+            "integrity": "sha512-yzk3AStN3cGfZ5Lkx+yb2ZSbLTlTvcbkbQ9e//5CtFac5VNoFGKmySWu/vhwwBt2dk19yHVWJb88YNw/Mb+Ufw==",
             "license": "PolyForm-Noncommercial-1.0.0"
         },
         "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "lint": "eslint"
     },
     "dependencies": {
-        "@do-md/core-react": "^0.2.10",
+        "@do-md/core-react": "^0.2.11",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-deep-link": "^2.4.8",
         "@tauri-apps/plugin-dialog": "^2.7.0",

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -7,6 +7,7 @@ two extension pipelines plus shared code:
 | ------------ | --------------- | ------------------------------------------------------------------------- | ----------------------------------------- |
 | `rendering/` | Enhanced render | Custom element rendering, decorations, node views — extend the view layer | `Renderer`, `RenderData`, `useRenderData` |
 | `parsing/`   | Enhanced parse  | Extend / override Markdown parsing, custom syntax token → RenderData      | `toMarkdown`, `MarkdownType`              |
+| `toolbar/`   | Editor chrome   | Toolbars / input bars around the editor surface (e.g. mobile quick-input) | `useEditorStoreApi`, `useEditorStore`     |
 | `shared/`    | Shared          | Types, registration logic, utilities shared across plugins                | —                                         |
 
 ## Conventions

--- a/plugins/rendering/CustomCursor/index.tsx
+++ b/plugins/rendering/CustomCursor/index.tsx
@@ -11,6 +11,34 @@ function injectBlinkStyle() {
     document.head.appendChild(style);
 }
 
+/** Starting from node (excluding itself), find the next leaf node within the same root */
+function getNextLeaf(node: Node, root: Node): Node | null {
+    let cur: Node | null = node;
+    while (cur && cur !== root) {
+        if (cur.nextSibling) {
+            let leaf: Node = cur.nextSibling;
+            while (leaf.firstChild) leaf = leaf.firstChild;
+            return leaf;
+        }
+        cur = cur.parentNode;
+    }
+    return null;
+}
+
+/** Measure the left edge of the character at `index` in a text node, used as the cursor rect */
+function measureCharLeft(node: Node, index: number): DOMRect | null {
+    const r = document.createRange();
+    r.setStart(node, index);
+    r.setEnd(node, index + 1);
+    const rects = r.getClientRects();
+    if (!rects.length) return null;
+    // A line-start character may return two rects (a zero-width rect at the end of
+    // the previous line + the character rect on this line); take the last one to
+    // bias toward "next line" — matching how the native caret is drawn at these positions.
+    const rect = rects[rects.length - 1];
+    return new DOMRect(rect.left, rect.top, 0, rect.height);
+}
+
 function getCursorRect(container: HTMLElement) {
     const sel = document.getSelection();
     if (!sel || sel.rangeCount === 0) return null;
@@ -19,10 +47,57 @@ function getCursorRect(container: HTMLElement) {
     let rect = range.getBoundingClientRect();
 
     if (rect.height === 0 && range.collapsed) {
-        const fallbackRange = range.cloneRange();
-        if (range.startOffset > 0) {
-            fallbackRange.setStart(range.startContainer, range.startOffset - 1);
-            fallbackRange.setEnd(range.startContainer, range.startOffset);
+        const node = range.startContainer;
+        const offset = range.startOffset;
+        const text =
+            node.nodeType === Node.TEXT_NODE ? node.textContent || "" : "";
+
+        // 1) Downstream first: measure the left edge of the character after the cursor.
+        //    At a line-start position the previous character is the \n at the end of the
+        //    previous line — using the upstream right edge would draw the cursor on the
+        //    previous line (the real cursor position is at the start of the next line).
+        if (node.nodeType === Node.TEXT_NODE && offset < text.length) {
+            rect = measureCharLeft(node, offset) || rect;
+        } else if (node.nodeType === Node.TEXT_NODE && offset === text.length) {
+            // End of node: downstream content may live in the next leaf (code block
+            // tokens are split into multiple spans, so a "line-start" position often
+            // lands at the end of the previous line's \n node)
+            const leaf = getNextLeaf(node, container);
+            if (leaf && leaf.nodeType === Node.TEXT_NODE) {
+                if ((leaf.textContent || "").length > 0) {
+                    rect = measureCharLeft(leaf, 0) || rect;
+                }
+            } else if (leaf instanceof HTMLElement) {
+                const leafRect = leaf.getBoundingClientRect();
+                if (leafRect.height > 0) {
+                    rect = new DOMRect(
+                        leafRect.left,
+                        leafRect.top,
+                        0,
+                        leafRect.height,
+                    );
+                }
+            }
+        } else if (node instanceof HTMLElement && node.tagName === "BR") {
+            // Empty paragraph: startContainer is the <br> itself
+            const brRect = node.getBoundingClientRect();
+            if (brRect.height > 0) {
+                rect = new DOMRect(brRect.left, brRect.top, 0, brRect.height);
+            }
+        }
+
+        // 2) Upstream fallback: the right edge of the previous character — only when
+        //    that previous character is not a \n (a \n's rect sits at the end of the
+        //    previous line, which would draw the cursor on the previous line)
+        if (
+            rect.height === 0 &&
+            node.nodeType === Node.TEXT_NODE &&
+            offset > 0 &&
+            text[offset - 1] !== "\n"
+        ) {
+            const fallbackRange = range.cloneRange();
+            fallbackRange.setStart(node, offset - 1);
+            fallbackRange.setEnd(node, offset);
             const rects = fallbackRange.getClientRects();
             if (rects.length > 0) {
                 const lastRect = rects[rects.length - 1];
@@ -32,32 +107,6 @@ function getCursorRect(container: HTMLElement) {
                     0,
                     lastRect.height,
                 );
-            }
-        } else {
-            const node = range.startContainer;
-            if (node.textContent && node.textContent.length > 0) {
-                fallbackRange.setStart(node, 0);
-                fallbackRange.setEnd(node, 1);
-                const rects = fallbackRange.getClientRects();
-                if (rects.length > 0) {
-                    rect = new DOMRect(
-                        rects[0].left,
-                        rects[0].top,
-                        0,
-                        rects[0].height,
-                    );
-                }
-            } else if (node instanceof HTMLElement && node.tagName === "BR") {
-                // Empty paragraph: startContainer is the <br> itself
-                const brRect = node.getBoundingClientRect();
-                if (brRect.height > 0) {
-                    rect = new DOMRect(
-                        brRect.left,
-                        brRect.top,
-                        0,
-                        brRect.height,
-                    );
-                }
             }
         }
     }

--- a/plugins/shared/use-visual-viewport-pin.ts
+++ b/plugins/shared/use-visual-viewport-pin.ts
@@ -1,0 +1,91 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export interface ViewportPin {
+    /** Visible-area height (CSS px) while the software keyboard is up. */
+    height: number;
+    /** Visible-area top offset within the layout viewport. */
+    top: number;
+}
+
+/**
+ * Software-keyboard geometry via the VisualViewport API — the only API that
+ * can sense the keyboard on iOS Safari/PWA (the VirtualKeyboard API is
+ * Chromium-only and dvh/svh units don't react to the keyboard at all).
+ *
+ * Returns null while no keyboard is present (use the static layout), else
+ * the rect to pin a fullscreen layer to so its bottom edge sits exactly on
+ * the keyboard's top edge:
+ *
+ *   outer: fixed inset-0 (opaque)
+ *     inner: absolute inset-x-0, top = pin.top, height = pin.height
+ *       ... content (flex-1 min-h-0) ...
+ *       toolbar (shrink-0)  <- lands on the keyboard's top edge
+ *
+ * Listens to BOTH `resize` and `scroll`: iOS pans the layout viewport when
+ * focusing inputs near the bottom, and offsetTop changes fire only `scroll`.
+ * A delayed re-read on focusout works around the iOS 26 rebound bug where
+ * vv geometry doesn't restore immediately after the keyboard collapses.
+ */
+export function useVisualViewportPin(threshold = 40): ViewportPin | null {
+    const [pin, setPin] = useState<ViewportPin | null>(null);
+
+    useEffect(() => {
+        const vv = window.visualViewport;
+        if (!vv) return;
+
+        const update = () => {
+            // Multiply by scale so pinch-zoom (which also shrinks vv.height)
+            // is not mistaken for a software keyboard.
+            const keyboardUp =
+                window.innerHeight - vv.height * vv.scale > threshold;
+            const next = keyboardUp
+                ? { height: vv.height, top: vv.offsetTop }
+                : null;
+            // Keep the previous object when the geometry is unchanged so
+            // downstream effects (caret scrolling, reveal gating) don't
+            // re-fire on every settle re-read.
+            setPin((prev) =>
+                prev &&
+                next &&
+                prev.height === next.height &&
+                prev.top === next.top
+                    ? prev
+                    : next,
+            );
+        };
+
+        // iOS 26 rebound bug: right after the keyboard collapses, vv events
+        // can still report stale height/offsetTop (especially when the
+        // keyboard is dismissed via its own chevron, which never blurs the
+        // editor, so a focusout-based fix alone doesn't cover it). After
+        // every event, re-read the geometry once more when it has settled
+        // so a stale pin self-heals.
+        let settleTimer: ReturnType<typeof setTimeout> | null = null;
+        const onVvChange = () => {
+            update();
+            if (settleTimer) clearTimeout(settleTimer);
+            settleTimer = setTimeout(update, 350);
+        };
+
+        let focusOutTimer: ReturnType<typeof setTimeout> | null = null;
+        const onFocusOut = () => {
+            if (focusOutTimer) clearTimeout(focusOutTimer);
+            focusOutTimer = setTimeout(update, 300);
+        };
+
+        update();
+        vv.addEventListener("resize", onVvChange);
+        vv.addEventListener("scroll", onVvChange);
+        window.addEventListener("focusout", onFocusOut, true);
+        return () => {
+            if (settleTimer) clearTimeout(settleTimer);
+            if (focusOutTimer) clearTimeout(focusOutTimer);
+            vv.removeEventListener("resize", onVvChange);
+            vv.removeEventListener("scroll", onVvChange);
+            window.removeEventListener("focusout", onFocusOut, true);
+        };
+    }, [threshold]);
+
+    return pin;
+}

--- a/plugins/toolbar/quick-input-bar/index.tsx
+++ b/plugins/toolbar/quick-input-bar/index.tsx
@@ -1,0 +1,119 @@
+"use client";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEditorStore, useEditorStoreApi } from "@do-md/core-react";
+import type { ViewportPin } from "@/plugins/shared/use-visual-viewport-pin";
+import { QUICK_INPUT_KEYS } from "./keys";
+
+const COARSE_POINTER = "(pointer: coarse)";
+
+function subscribePointerType(onChange: () => void) {
+    const mql = window.matchMedia(COARSE_POINTER);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+}
+
+function getIsTouchSnapshot() {
+    return window.matchMedia(COARSE_POINTER).matches;
+}
+
+// Dev override (`?quickbar=1`): keeps the bar permanently visible so it can
+// be exercised on desktop where no software keyboard ever shows up.
+const subscribeNoop = () => () => {};
+function getForcedSnapshot() {
+    return new URLSearchParams(window.location.search).has("quickbar");
+}
+
+/**
+ * Mobile quick-input toolbar: a horizontal, scrollable row of Markdown
+ * snippet keys riding on top of the software keyboard.
+ *
+ * Shown only while the keyboard is up (`pin` non-null, driven by
+ * useVisualViewportPin in the editor layout) on touch devices. The host
+ * layout pins itself to the visual viewport and sets --kb-safe-bottom to
+ * 0px while the keyboard is up — the home indicator sits behind the
+ * keyboard, so the safe-area inset must not be padded twice.
+ */
+export function QuickInputBar({ pin = null }: { pin?: ViewportPin | null }) {
+    const store = useEditorStoreApi();
+    const isEditable = useEditorStore((s) => s.isEditable);
+    const isTouch = useSyncExternalStore(
+        subscribePointerType,
+        getIsTouchSnapshot,
+        () => false,
+    );
+    const forced = useSyncExternalStore(
+        subscribeNoop,
+        getForcedSnapshot,
+        () => false,
+    );
+
+    const show = (forced || (isTouch && pin !== null)) && isEditable;
+    const pinHeight = pin?.height ?? null;
+
+    // Stability-gated reveal: the bar stays invisible (opacity 0, but still
+    // occupying flex space so the layout doesn't reflow) until the keyboard
+    // geometry has stopped moving. iOS — especially on a re-open after the
+    // iOS 26 rebound bug left stale vv values — can emit a burst of
+    // intermediate heights while the keyboard animates; painting the bar
+    // during that burst shows it ghosting through transient positions.
+    // Every height change restarts the timer, so the bar fades in only
+    // 120ms after the geometry went quiet. offsetTop-only changes (user
+    // panning with the keyboard up) do NOT re-hide it.
+    const [visible, setVisible] = useState(false);
+    useEffect(() => {
+        if (!show) {
+            setVisible(false);
+            return;
+        }
+        // Forced desktop mode with no keyboard: static dock, nothing to settle.
+        if (pinHeight == null) {
+            setVisible(true);
+            return;
+        }
+        setVisible(false);
+        const timer = setTimeout(() => setVisible(true), 120);
+        return () => clearTimeout(timer);
+    }, [show, pinHeight]);
+
+    if (!show) return null;
+
+    return (
+        <div
+            className="shrink-0 flex items-center gap-0.5 overflow-x-auto border-t border-base-300 bg-base-200 px-1.5 pt-1"
+            style={{
+                paddingBottom:
+                    "max(var(--kb-safe-bottom, env(safe-area-inset-bottom)), 0.25rem)",
+                opacity: visible ? 1 : 0,
+                // Fade in on reveal; vanish instantly when re-hidden so a
+                // moving frame never shows mid-fade.
+                transition: visible ? "opacity 120ms ease-out" : "none",
+                pointerEvents: visible ? "auto" : "none",
+            }}
+        >
+            {QUICK_INPUT_KEYS.map((key) => (
+                <button
+                    key={key.id}
+                    type="button"
+                    title={key.title}
+                    aria-label={key.title}
+                    // Apple Notes-sized caps: ~44x40pt tap targets, roomy
+                    // 22px stroke icons / 19px glyphs. Overflow scrolls.
+                    className="btn btn-ghost h-10 min-h-0 w-11 shrink-0 rounded-lg p-0 text-base-content/80"
+                    // Critical: prevent the tap from stealing focus from the
+                    // contenteditable — otherwise the editor blurs and the
+                    // software keyboard collapses before the click lands.
+                    onPointerDown={(e) => e.preventDefault()}
+                    onClick={() =>
+                        store?.insertText(
+                            key.insertText,
+                            undefined,
+                            key.cursorOffset,
+                        )
+                    }
+                >
+                    {key.cap}
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/plugins/toolbar/quick-input-bar/keys.tsx
+++ b/plugins/toolbar/quick-input-bar/keys.tsx
@@ -1,0 +1,186 @@
+import type { ReactNode } from "react";
+
+/**
+ * Markdown quick-input key set for the mobile toolbar.
+ *
+ * Each key inserts `insertText` at the caret and then repositions the caret
+ * by `cursorOffset`, measured from the END of the inserted text (0 = caret
+ * stays after the whole insertion, negative = step left into it). The offset
+ * is applied via `EditorStore.insertText(text, undefined, cursorOffset)`.
+ *
+ * Key caps follow the Apple Notes format-bar language: typographic glyphs
+ * for text styles (B / I / #), stroke icons for structural keys. Icons are
+ * hand-inlined 24x24 stroke SVGs (lucide-style geometry) so the plugin stays
+ * dependency-free and every cap shares the same stroke weight.
+ */
+export interface QuickInputKey {
+    /** Stable identity for React keys. */
+    id: string;
+    /** Key cap content (glyph span or SVG icon). */
+    cap: ReactNode;
+    /** Text inserted at the caret. */
+    insertText: string;
+    /** Caret offset from the end of the inserted text (negative = leftwards). */
+    cursorOffset: number;
+    /** Accessible description (title / aria-label). */
+    title: string;
+}
+
+function Icon({ children }: { children: ReactNode }) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.8}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="size-[22px]"
+            aria-hidden
+        >
+            {children}
+        </svg>
+    );
+}
+
+function Glyph({
+    children,
+    className = "",
+}: {
+    children: ReactNode;
+    className?: string;
+}) {
+    return (
+        <span className={`text-[19px] leading-none ${className}`}>
+            {children}
+        </span>
+    );
+}
+
+export const QUICK_INPUT_KEYS: QuickInputKey[] = [
+    {
+        id: "tab",
+        title: "Tab",
+        insertText: "\t",
+        cursorOffset: 0,
+        cap: (
+            <Icon>
+                <polyline points="3 8 7 12 3 16" />
+                <line x1="21" x2="11" y1="6" y2="6" />
+                <line x1="21" x2="11" y1="12" y2="12" />
+                <line x1="21" x2="11" y1="18" y2="18" />
+            </Icon>
+        ),
+    },
+    {
+        // Bare "#" with no trailing space so repeated taps build multi-level
+        // headings (##, ###) before the user types the space + text.
+        id: "heading",
+        title: "Heading",
+        insertText: "#",
+        cursorOffset: 0,
+        cap: <Glyph className="font-semibold">#</Glyph>,
+    },
+    {
+        // Ordered list: needs the trailing space to be parsed as a marker.
+        id: "ordered-list",
+        title: "Ordered list",
+        insertText: "1. ",
+        cursorOffset: 0,
+        cap: (
+            <Icon>
+                <line x1="10" x2="21" y1="6" y2="6" />
+                <line x1="10" x2="21" y1="12" y2="12" />
+                <line x1="10" x2="21" y1="18" y2="18" />
+                <path d="M4 6h1v4" />
+                <path d="M4 10h2" />
+                <path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1" />
+            </Icon>
+        ),
+    },
+    {
+        id: "bullet-list",
+        title: "Bullet list",
+        insertText: "- ",
+        cursorOffset: 0,
+        cap: (
+            <Icon>
+                <line x1="8" x2="21" y1="6" y2="6" />
+                <line x1="8" x2="21" y1="12" y2="12" />
+                <line x1="8" x2="21" y1="18" y2="18" />
+                <line x1="3" x2="3.01" y1="6" y2="6" />
+                <line x1="3" x2="3.01" y1="12" y2="12" />
+                <line x1="3" x2="3.01" y1="18" y2="18" />
+            </Icon>
+        ),
+    },
+    {
+        id: "checklist",
+        title: "Checklist",
+        insertText: "- [ ] ",
+        cursorOffset: 0,
+        cap: (
+            <Icon>
+                <path d="m3 17 2 2 4-4" />
+                <path d="m3 7 2 2 4-4" />
+                <path d="M13 6h8" />
+                <path d="M13 12h8" />
+                <path d="M13 18h8" />
+            </Icon>
+        ),
+    },
+    {
+        // Code fence: just the opening ``` — the user presses Enter themselves.
+        id: "code-block",
+        title: "Code block",
+        insertText: "```",
+        cursorOffset: 0,
+        cap: (
+            <Icon>
+                <polyline points="16 18 22 12 16 6" />
+                <polyline points="8 6 2 12 8 18" />
+            </Icon>
+        ),
+    },
+    {
+        id: "quote",
+        title: "Quote",
+        insertText: "> ",
+        cursorOffset: 0,
+        cap: (
+            <Icon>
+                <path d="M17 6H3" />
+                <path d="M21 12H8" />
+                <path d="M21 18H8" />
+                <path d="M3 12v6" />
+            </Icon>
+        ),
+    },
+    {
+        id: "bold",
+        title: "Bold",
+        insertText: "****",
+        cursorOffset: -2,
+        cap: <Glyph className="font-bold">B</Glyph>,
+    },
+    {
+        id: "italic",
+        title: "Italic",
+        insertText: "**",
+        cursorOffset: -1,
+        cap: <Glyph className="font-serif italic">I</Glyph>,
+    },
+    {
+        id: "highlight",
+        title: "Highlight",
+        insertText: "====",
+        cursorOffset: -2,
+        cap: (
+            <Icon>
+                <path d="m9 11-6 6v3h9l3-3" />
+                <path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4" />
+            </Icon>
+        ),
+    },
+];


### PR DESCRIPTION
## Summary

- **Mobile quick-input bar** — a toolbar pinned above the software keyboard using `visualViewport` (`plugins/toolbar/quick-input-bar` + `plugins/shared/use-visual-viewport-pin.ts`). Adds `viewport-fit=cover` in the root layout so `env(safe-area-inset-*)` is non-zero on notched iPhones and the bar pads itself above the home indicator.
- **Code-block cursor fix** — corrects custom cursor rendering position inside code blocks: measures the downstream character's left edge and handles token spans that Prism splits across multiple leaf nodes.
- **Table border optimization** — bump `@do-md/core-react` 0.2.10 → 0.2.11.

## Notes

- Both desktop (Tauri) and Web paths preserved.
- CustomCursor comments translated to English (no logic change).

## Test plan

- [ ] Mobile: quick-input bar stays pinned above the keyboard while typing; sits above the home indicator on notched devices
- [ ] Desktop/Web: caret renders at the correct position inside code blocks (line starts, token-split spans)
- [ ] Tables render with the updated borders