### PR TITLE
feat(editor): web PDF export in the three-dot menu

### DIFF
--- a/common/i18n/locales/en.json
+++ b/common/i18n/locales/en.json
@@ -51,6 +51,7 @@
         "download": "Download",
         "downloading": "Downloading…",
         "downloaded": "Downloaded",
+        "exportPdf": "Export PDF",
         "newDoc": "New",
         "newDocModal": {
             "title": "Start a new document?",

--- a/common/i18n/locales/ja.json
+++ b/common/i18n/locales/ja.json
@@ -51,6 +51,7 @@
         "download": "ダウンロード",
         "downloading": "ダウンロード中…",
         "downloaded": "完了",
+        "exportPdf": "PDF に書き出し",
         "newDoc": "新規",
         "newDocModal": {
             "title": "新しいドキュメントを作成しますか？",

--- a/common/i18n/locales/zh.json
+++ b/common/i18n/locales/zh.json
@@ -51,6 +51,7 @@
         "download": "下载",
         "downloading": "下载中…",
         "downloaded": "已下载",
+        "exportPdf": "导出 PDF",
         "newDoc": "新建",
         "newDocModal": {
             "title": "新建空白文档？",

--- a/features/editor/components/editor.tsx
+++ b/features/editor/components/editor.tsx
@@ -25,6 +25,7 @@ import { useAutoSave } from "../hooks/use-auto-save";
 import { useLocalDraft } from "../hooks/use-local-draft";
 import { useTauriEvent } from "../hooks/use-tauri-event";
 import { saveDocument } from "../lib/save-document";
+import { exportToPdf } from "../lib/export-pdf";
 import type { FileMeta } from "../lib/types";
 import { CustomCursor } from "@/plugins/rendering/CustomCursor";
 import { QuickInputBar } from "@/plugins/toolbar/quick-input-bar";
@@ -498,6 +499,19 @@ export function Editor({
                                             : saved
                                               ? t("editor.downloaded")
                                               : t("editor.download")}
+                                    </button>
+                                </li>
+                                <li>
+                                    <button
+                                        onClick={(e) => {
+                                            e.currentTarget.blur();
+                                            exportToPdf(
+                                                domdRef.current,
+                                                getTitle() || meta.name,
+                                            );
+                                        }}
+                                    >
+                                        {t("editor.exportPdf")}
                                     </button>
                                 </li>
                             </ul>

--- a/features/editor/lib/export-pdf.ts
+++ b/features/editor/lib/export-pdf.ts
@@ -1,0 +1,220 @@
+// Web-only "Export PDF".
+//
+// The editor already renders a faithful, vector, WYSIWYG DOM (`data-domd-root`)
+// with Prism-highlighted code, tables, images and task lists. The browser's own
+// print engine turns that into a paginated, selectable, vector PDF for free — so
+// export is just: clone the rendered DOM into an isolated iframe, apply a print
+// stylesheet, and let the user "Save as PDF". No canvas, no rasterization, no
+// second render engine to keep in sync with the editor.
+
+// Print-time overrides layered on top of the editor's own stylesheets.
+const PRINT_CSS = `
+/* margin:0 suppresses the browser's default print header/footer (URL, date,
+   page number) — with no page-margin box, Chrome/Edge have nowhere to draw
+   them, so they're off by default. The visual page margins are re-applied as
+   padding on the content wrapper below. (The user can still re-enable
+   headers/footers in the print dialog; this only sets the default.) */
+@page { margin: 0; }
+html, body { background: #fff !important; height: auto !important; }
+body { margin: 0; }
+.domd-pdf-page {
+    box-sizing: border-box;
+    width: 100%;
+    margin: 0 auto;
+    padding: 16mm 14mm;
+    color: var(--color-base-content, #141414);
+}
+[data-domd-root] { min-height: 0 !important; }
+/* Keep code-block backgrounds, highlight marks and syntax colors in the PDF. */
+* { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+/* Markdown syntax markers only surface on the active editing line; force them
+   off so the PDF reads as a rendered document, not raw markdown. */
+.DOMD-MdSymbol { display: none !important; }
+/* Don't slice atomic blocks across page boundaries where they fit on one page. */
+pre, blockquote, table, img, figure,
+.DOMD-Pre, .DOMD-Table, .DOMD-Blockquote { break-inside: avoid; }
+h1, h2, h3, h4, h5, h6 { break-after: avoid; }
+`;
+
+function escapeHtml(s: string): string {
+    return s
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+}
+
+function escapeAttr(s: string): string {
+    return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+// Reproduce the parent document's stylesheets inside the print iframe so the
+// clone is styled identically. Covers both Next dev (inline <style>, Turbopack)
+// and static export (<link> to /_next/static/css).
+function collectHeadStyles(): string {
+    const nodes = document.head.querySelectorAll(
+        'style, link[rel="stylesheet"]',
+    );
+    const parts: string[] = [];
+    for (const node of Array.from(nodes)) {
+        if (node instanceof HTMLLinkElement) {
+            if (node.href) {
+                parts.push(
+                    `<link rel="stylesheet" href="${escapeAttr(node.href)}">`,
+                );
+            }
+        } else if (node instanceof HTMLStyleElement) {
+            parts.push(`<style>${node.textContent ?? ""}</style>`);
+        }
+    }
+    return parts.join("\n");
+}
+
+// Strip editing chrome from the cloned tree so it prints as a static document.
+function cleanClone(el: HTMLElement): void {
+    el.removeAttribute("contenteditable");
+    el.removeAttribute("spellcheck");
+    el.removeAttribute("tabindex");
+    el.querySelectorAll("[contenteditable]").forEach((n) =>
+        n.removeAttribute("contenteditable"),
+    );
+    // Drop the CustomCursor portal node (teal caret overlay) — it lives inside
+    // the editor root and is identified by its distinctive `contain: strict`.
+    el.querySelectorAll(
+        '[style*="contain: strict"], [style*="contain:strict"]',
+    ).forEach((n) => n.remove());
+}
+
+// Wait for the reproduced stylesheets to load. This is CRITICAL: the app's real
+// styling lives in async <link> chunks (Tailwind/DaisyUI + the editor's own CSS),
+// and a fresh iframe fetches them anew. Print before they arrive and the PDF
+// captures the unstyled, UA-default DOM (no theme, no backgrounds, no fonts).
+// A stylesheet is ready once its `.sheet` is populated; otherwise wait for load.
+function waitForStyles(doc: Document): Promise<void> {
+    const links = Array.from(
+        doc.querySelectorAll('link[rel="stylesheet"]'),
+    ) as HTMLLinkElement[];
+    const waits = links.map((link) =>
+        link.sheet
+            ? Promise.resolve()
+            : new Promise<void>((resolve) => {
+                  link.addEventListener("load", () => resolve(), {
+                      once: true,
+                  });
+                  link.addEventListener("error", () => resolve(), {
+                      once: true,
+                  });
+              }),
+    );
+    const ready = Promise.all(waits).then(() => undefined);
+    const cap = new Promise<void>((resolve) => setTimeout(resolve, 5000));
+    return Promise.race([ready, cap]);
+}
+
+// Yield two frames so a style/layout recalc flushes before we hand off to print.
+function nextFrame(win: Window): Promise<void> {
+    return new Promise((resolve) =>
+        win.requestAnimationFrame(() =>
+            win.requestAnimationFrame(() => resolve()),
+        ),
+    );
+}
+
+// Wait for images and fonts so nothing prints half-loaded, with a hard cap so a
+// stuck asset can never block the print dialog.
+function waitForAssets(doc: Document): Promise<void> {
+    const imgWaits = Array.from(doc.images).map((img) =>
+        img.complete
+            ? Promise.resolve()
+            : new Promise<void>((resolve) => {
+                  img.addEventListener("load", () => resolve(), { once: true });
+                  img.addEventListener("error", () => resolve(), {
+                      once: true,
+                  });
+              }),
+    );
+    const fontWait = doc.fonts?.ready
+        ? doc.fonts.ready.then(() => undefined).catch(() => undefined)
+        : Promise.resolve();
+    const ready = Promise.all([...imgWaits, fontWait]).then(() => undefined);
+    const cap = new Promise<void>((resolve) => setTimeout(resolve, 3000));
+    return Promise.race([ready, cap]);
+}
+
+/**
+ * Open the browser's print-to-PDF flow for the current document.
+ *
+ * @param container The wrapper holding the editor (the `[data-domd-root]` inside
+ *                  it is what gets exported).
+ * @param title     Used as the print document title → the default PDF filename.
+ */
+export function exportToPdf(container: HTMLElement | null, title: string): void {
+    if (typeof window === "undefined") return;
+    const root =
+        (container?.querySelector("[data-domd-root]") as HTMLElement | null) ??
+        container;
+    if (!root) return;
+
+    const clone = root.cloneNode(true) as HTMLElement;
+    cleanClone(clone);
+
+    const iframe = document.createElement("iframe");
+    iframe.setAttribute("aria-hidden", "true");
+    Object.assign(iframe.style, {
+        position: "fixed",
+        right: "0",
+        bottom: "0",
+        width: "0",
+        height: "0",
+        border: "0",
+        visibility: "hidden",
+    });
+    document.body.appendChild(iframe);
+
+    const doc = iframe.contentDocument;
+    const win = iframe.contentWindow;
+    if (!doc || !win) {
+        iframe.remove();
+        return;
+    }
+
+    const safeTitle = (title || "document").trim() || "document";
+    doc.open();
+    doc.write(
+        `<!doctype html><html data-theme="light" style="color-scheme: light"><head>` +
+            `<meta charset="utf-8">` +
+            `<base href="${escapeAttr(window.location.href)}">` +
+            `<title>${escapeHtml(safeTitle)}</title>` +
+            collectHeadStyles() +
+            `<style>${PRINT_CSS}</style>` +
+            `</head><body><div class="domd-pdf-page">${clone.outerHTML}</div></body></html>`,
+    );
+    doc.close();
+
+    let cleaned = false;
+    const cleanup = () => {
+        if (cleaned) return;
+        cleaned = true;
+        // Defer removal so the print preview keeps its source document.
+        setTimeout(() => iframe.remove(), 500);
+    };
+
+    const triggerPrint = async () => {
+        // Stylesheets first — printing before they load yields an unstyled PDF.
+        await waitForStyles(doc);
+        await waitForAssets(doc);
+        await nextFrame(win);
+        win.addEventListener("afterprint", cleanup, { once: true });
+        // Fallback: some engines never fire afterprint (or the user cancels).
+        setTimeout(cleanup, 60000);
+        win.focus();
+        win.print();
+    };
+
+    if (doc.readyState === "complete") {
+        void triggerPrint();
+    } else {
+        iframe.addEventListener("load", () => void triggerPrint(), {
+            once: true,
+        });
+    }
+}


### PR DESCRIPTION
## What

Adds an **Export PDF** item to the editor's three-dot menu (web mode).

Export reuses the editor's already-rendered vector WYSIWYG DOM and the browser's native print engine — no canvas, no rasterization, no second render engine to keep in sync. The clone is placed in an isolated iframe, the page stylesheets are reproduced, a print stylesheet is applied, and print is triggered.

## Details

- **Wait for stylesheets before printing.** All Tailwind/DaisyUI and editor CSS ships in async `<link>` chunks; a fresh iframe re-fetches them, and printing before they load produced an unstyled, UA-default PDF. Print now waits for every `link[rel=stylesheet]` to load, then images/fonts, then two frames.
- **Clean rendering.** Strips editing chrome (`contenteditable`, the CustomCursor overlay) and hides markdown syntax markers so the output reads as a rendered document.
- **Fidelity.** Keeps code-block/highlight backgrounds via `print-color-adjust: exact`; avoids splitting atomic blocks (code/tables/blockquotes/images) across page boundaries.
- **No header/footer by default.** `@page { margin: 0 }` suppresses the browser's default header/footer; page margins are re-applied as content padding. (Users can still re-enable headers/footers in the print dialog.)
- **Filename.** Sets the print document title so it becomes the default PDF filename.
- **i18n.** `editor.exportPdf` for en/zh/ja.

## Scope / follow-ups

- Web mode only. Desktop (Tauri) export via native `printToPDF` (`displayHeaderFooter: false`, one-click to file) is a follow-up.
- Known trade-off of `@page { margin: 0 }`: continuation pages of long multi-page documents have no top/bottom margin (left/right padding still applies).

## Testing

Verified in Chrome against a document with headings, code block, table, task list and blockquote: the print document builds with all stylesheets loaded, `contenteditable` stripped, cursor node removed, white page, correct editor typography, preserved code-block backgrounds, and hidden markdown markers. The native print dialog itself is user-driven and not automated.
