### PR TITLE
fix(app): keep vendored packages' build tooling out of the app program

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,8 +62,8 @@
         "services/**",
         "scripts/**",
         ".packages/**/node_modules/**",
-        ".packages/@do-md/core/scripts/**",
-        ".packages/@do-md/core/vite.config.ts",
-        ".packages/@do-md/core/dist/**"
+        ".packages/**/scripts/**",
+        ".packages/**/*.config.ts",
+        ".packages/**/dist/**"
     ]
 }


### PR DESCRIPTION
#23 broke the deploy: `npm run build` fails on Vercel with

```
.packages/@do-md/plugins/commands/vite.config.ts:1:30
Type error: Cannot find module 'vite' or its corresponding type declarations.
```

The app's `tsconfig.json` includes `.packages/**/*.ts` on purpose — vendored package sources are typechecked together with the app, which is how kernel type drift gets caught. But that also swept up the new plugin package's `vite.config.ts`, and `import { defineConfig } from "vite"` only resolves once that package's own `node_modules` has been installed. Locally it has been; CI installs the app's dependencies and nothing else, so the build died on a file no app code imports.

The kernel already carried one-off excludes for exactly this case (`core/scripts/**`, `core/vite.config.ts`, `core/dist/**`). Rather than appending three more lines per package, they become package-agnostic patterns:

```
".packages/**/scripts/**",
".packages/**/*.config.ts",
".packages/**/dist/**"
```

Every plugin package added from here on is covered by construction instead of by remembering to extend a list.

**Verified** with the plugin package's `node_modules` and `dist` moved aside — i.e. the tree CI actually sees: the original error reproduces before the change, and `tsc --noEmit` plus `next build` (14 static pages) are clean after it.