### PR TITLE
feat: in-document find & replace (Cmd+F find widget)

### DIFF
--- a/.packages/@do-md/core/.gitignore
+++ b/.packages/@do-md/core/.gitignore
@@ -79,3 +79,4 @@ scripts/verify-img-group/out.mjs
 scripts/verify-img-group/out.css
 scripts/verify-empty-blocks/out.mjs
 scripts/verify-table-after-paragraph/out.mjs
+scripts/verify-resolve-ranges/out.mjs

--- a/.packages/@do-md/core/scripts/verify-resolve-ranges/entry.ts
+++ b/.packages/@do-md/core/scripts/verify-resolve-ranges/entry.ts
@@ -1,0 +1,287 @@
+/**
+ * Headless assertion matrix for EditorStore.resolveRanges — the batch,
+ * side-effect-free companion of setSelection. Run:
+ *   sh scripts/verify-resolve-ranges/run.sh
+ *
+ * Instantiates the REAL EditorStore (no DOM) and asserts:
+ *
+ *   1. EQUIVALENCE — for every corpus needle, resolveRanges returns exactly
+ *      the block coordinates setSelection places for the same absolute range.
+ *      Oracle: getCursorSnapshot after setSelection on the same store —
+ *      resolveRanges runs FIRST (on a virgin cursor), so the equivalence also
+ *      proves resolution is independent of cursor state. Failure equivalence
+ *      included: resolveRanges yields null exactly when setSelection reports
+ *      applied:false.
+ *   2. PURITY — resolveRanges fires no cursor event, leaves the cursor
+ *      snapshot bit-identical, emits no renderData ops and does not touch the
+ *      document text.
+ *   3. BATCH SHAPE — the result array corresponds positionally to the
+ *      arguments; malformed / out-of-bounds entries yield null while valid
+ *      neighbours still resolve.
+ *   4. COLLAPSED — `end` omitted or equal to `start` echoes the start anchor
+ *      at both endpoints.
+ */
+import { EditorStore } from "../../src/editor/store";
+import { SelectionRangeTarget } from "../../src/editor/model/selection/resolve";
+
+/* eslint-disable no-console */
+const rawLog = console.log.bind(console);
+console.log = () => {};
+console.time = () => {};
+console.timeEnd = () => {};
+
+let passes = 0;
+let failures = 0;
+const check = (name: string, cond: boolean, detail?: unknown) => {
+    if (cond) {
+        passes += 1;
+    } else {
+        failures += 1;
+        rawLog(`✗ ${name}`, detail !== undefined ? JSON.stringify(detail) : "");
+    }
+};
+
+const makeStore = (initMd: string) =>
+    new EditorStore({ editable: true, initMd });
+
+// ---------------------------------------------------------------------------
+// 1. Equivalence with setSelection, per block type
+// ---------------------------------------------------------------------------
+
+interface Case {
+    name: string;
+    md: string;
+    search: string;
+}
+
+const CASES: Case[] = [
+    { name: "paragraph", md: "alpha beta gamma", search: "beta" },
+    {
+        name: "paragraph mid-doc",
+        md: "first para\n\nsecond para here\n\nthird para",
+        search: "para here",
+    },
+    { name: "header", md: "# Title of doc\n\nbody", search: "of doc" },
+    {
+        name: "inline formatting (span boundary)",
+        md: "plain **bold text** tail",
+        search: "bold text",
+    },
+    {
+        name: "inline formatting incl. symbols",
+        md: "plain **bold text** tail",
+        search: "**bold text**",
+    },
+    {
+        name: "unordered list item",
+        md: "- first item\n- second item\n- third item",
+        search: "second item",
+    },
+    {
+        name: "ordered list item",
+        md: "1. alpha step\n2. beta step\n3. gamma step",
+        search: "beta step",
+    },
+    {
+        name: "nested list item",
+        md: "- outer one\n  - inner deep\n- outer two",
+        search: "inner deep",
+    },
+    {
+        name: "blockquote",
+        md: "> quoted line one\n> quoted line two",
+        search: "line two",
+    },
+    {
+        name: "table body cell",
+        md: "| a  | bb |\n| -- | -- |\n| cc | dd |",
+        search: "cc",
+    },
+    {
+        name: "table widest cell (padding reflow)",
+        md: "| h | col |\n| - | --- |\n| x | wideeeee |\n| y | z |",
+        search: "wideeeee",
+    },
+    {
+        name: "table header cell",
+        md: "| name | value |\n| ---- | ----- |\n| a    | b     |",
+        search: "value",
+    },
+    {
+        name: "code block body",
+        md: "```js\nconst x = 1;\nconst y = 2;\n```",
+        search: "const y = 2;",
+    },
+    {
+        name: "paragraph after code block",
+        md: "```js\nfoo();\n```\n\ntrailing paragraph",
+        search: "trailing paragraph",
+    },
+    {
+        name: "checkbox list",
+        md: "- [ ] todo one\n- [x] done two",
+        search: "todo one",
+    },
+    {
+        name: "multi-line selection inside a paragraph",
+        md: "line one soft\nline two soft",
+        search: "soft\nline two",
+    },
+    {
+        name: "cross-block selection",
+        md: "para one here\n\npara two here",
+        search: "one here\n\npara two",
+    },
+];
+
+/** Every non-overlapping occurrence of `needle`, left to right. */
+const occurrencesOf = (doc: string, needle: string): SelectionRangeTarget[] => {
+    const out: SelectionRangeTarget[] = [];
+    let from = 0;
+    for (;;) {
+        const at = doc.indexOf(needle, from);
+        if (at === -1) return out;
+        out.push({ start: at, end: at + needle.length });
+        from = at + needle.length;
+    }
+};
+
+for (const c of CASES) {
+    const store = makeStore(c.md);
+    const doc = store.toMarkdown();
+    const targets = occurrencesOf(doc, c.search);
+    check(`${c.name}: needle occurs`, targets.length > 0, { doc });
+
+    // resolveRanges first — the cursor is still virgin here.
+    const resolved = store.resolveRanges(...targets);
+    check(
+        `${c.name}: one slot per target`,
+        resolved.length === targets.length,
+        resolved,
+    );
+
+    targets.forEach((target, i) => {
+        const label = targets.length > 1 ? `${c.name} #${i}` : c.name;
+        const res = store.setSelection(target);
+        const slot = resolved[i];
+        check(
+            `${label}: null exactly when setSelection fails`,
+            (slot === null) === (res.applied === false),
+            { slot, res },
+        );
+        if (!res.applied || slot === null) return;
+        const snap = store.getCursorSnapshot();
+        check(`${label}: snapshot has endpoints`, !!snap.start && !!snap.end, snap);
+        check(
+            `${label}: start anchor equals setSelection placement`,
+            slot.start.uuid === snap.start?.uuid &&
+                slot.start.offset === snap.start?.offset,
+            { slot: slot.start, snap: snap.start },
+        );
+        check(
+            `${label}: end anchor equals setSelection placement`,
+            slot.end.uuid === snap.end?.uuid &&
+                slot.end.offset === snap.end?.offset,
+            { slot: slot.end, snap: snap.end },
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// 2. Purity — no cursor event, no ops, snapshot and document untouched
+// ---------------------------------------------------------------------------
+
+{
+    const store = makeStore("alpha beta gamma\n\n- item one\n- item two");
+    const doc = store.toMarkdown();
+    store.setSelection({ search: "beta" });
+    const before = JSON.stringify(store.getCursorSnapshot());
+
+    let cursorEvents = 0;
+    let opBatches = 0;
+    const offCursor = store.subscribeCursorChange(() => {
+        cursorEvents += 1;
+    });
+    const offOps = store.subscribeRenderDataOps(() => {
+        opBatches += 1;
+    });
+    const resolved = store.resolveRanges(
+        ...occurrencesOf(doc, "item"),
+        { start: 0, end: doc.length },
+    );
+    offCursor();
+    offOps();
+
+    check("purity: all slots resolved", resolved.every((slot) => slot !== null));
+    check("purity: zero cursor events", cursorEvents === 0, cursorEvents);
+    check("purity: zero op batches", opBatches === 0, opBatches);
+    check(
+        "purity: cursor snapshot untouched",
+        JSON.stringify(store.getCursorSnapshot()) === before,
+    );
+    check("purity: document untouched", store.toMarkdown() === doc);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Batch shape — positional correspondence, per-slot failure
+// ---------------------------------------------------------------------------
+
+{
+    const store = makeStore("repeat me\n\nrepeat me");
+    const doc = store.toMarkdown();
+    const [first, second] = occurrencesOf(doc, "repeat me");
+    const resolved = store.resolveRanges(
+        first,
+        { start: -1, end: 2 }, // out of bounds
+        second,
+        { start: 4, end: 2 }, // malformed (end < start)
+        { start: 0, end: doc.length + 10 }, // out of bounds
+        { start: 2.5, end: 4 } as SelectionRangeTarget, // malformed (non-integer)
+    );
+    check("batch: six slots", resolved.length === 6, resolved);
+    check("batch: valid slot 0 resolves", resolved[0] !== null);
+    check("batch: invalid slot 1 is null", resolved[1] === null);
+    check("batch: valid slot 2 resolves", resolved[2] !== null);
+    check("batch: invalid slot 3 is null", resolved[3] === null);
+    check("batch: invalid slot 4 is null", resolved[4] === null);
+    check("batch: invalid slot 5 is null", resolved[5] === null);
+    check(
+        "batch: duplicate needles land on distinct blocks",
+        resolved[0]?.start.uuid !== resolved[2]?.start.uuid,
+        resolved,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Collapsed ranges echo the start anchor
+// ---------------------------------------------------------------------------
+
+{
+    const store = makeStore("alpha beta gamma");
+    const collapsed = store.resolveRanges({ start: 6 }, { start: 6, end: 6 });
+    for (const [i, slot] of collapsed.entries()) {
+        check(`collapsed #${i}: resolves`, slot !== null);
+        check(
+            `collapsed #${i}: end echoes start`,
+            slot !== null &&
+                slot.start.uuid === slot.end.uuid &&
+                slot.start.offset === slot.end.offset,
+            slot,
+        );
+    }
+    const res = store.setSelection({ start: 6 });
+    const snap = store.getCursorSnapshot();
+    check("collapsed: setSelection applied", res.applied === true, res);
+    check(
+        "collapsed: anchor equals setSelection placement",
+        collapsed[0]?.start.uuid === snap.start?.uuid &&
+            collapsed[0]?.start.offset === snap.start?.offset,
+        { slot: collapsed[0], snap: snap.start },
+    );
+
+    // Zero arguments → empty result, still pure.
+    check("collapsed: empty call yields []", store.resolveRanges().length === 0);
+}
+
+rawLog(`resolveRanges verification: ${passes} passed, ${failures} failed`);
+if (failures > 0) process.exit(1);

--- a/.packages/@do-md/core/scripts/verify-resolve-ranges/run.sh
+++ b/.packages/@do-md/core/scripts/verify-resolve-ranges/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# resolveRanges headless verification (batch, side-effect-free range resolution).
+# Run from the core package root: sh scripts/verify-resolve-ranges/run.sh
+cd "$(dirname "$0")/../.." || exit 1
+npx esbuild scripts/verify-resolve-ranges/entry.ts \
+  --bundle \
+  --format=esm \
+  --platform=node \
+  --jsx=automatic \
+  --alias:@do-md/utils=../utils \
+  --alias:@do-md/zenith=../zenith \
+  --outfile=scripts/verify-resolve-ranges/out.mjs || exit 1
+node scripts/verify-resolve-ranges/out.mjs

--- a/.packages/@do-md/core/src/editor/model/selection/resolve.ts
+++ b/.packages/@do-md/core/src/editor/model/selection/resolve.ts
@@ -98,6 +98,23 @@ export interface SelectionResult {
     end?: number;
 }
 
+/**
+ * One resolved endpoint: a block-level cursor coordinate — the vocabulary
+ * CursorSnapshot already speaks (block uuid + in-block text offset), so a
+ * consumer positions it in the DOM the same way it draws a remote cursor
+ * (`[data-render-id]` + a text walk).
+ */
+export interface ResolvedRangeAnchor {
+    uuid: string;
+    offset: number;
+}
+
+/** An absolute markdown range resolved to block coordinates (resolveRanges). */
+export interface ResolvedRange {
+    start: ResolvedRangeAnchor;
+    end: ResolvedRangeAnchor;
+}
+
 /** Parser injections threaded from the store so the reparse of step 2 builds
  *  the same tree shape the live document was built with. */
 export interface SelectionParseOptions {

--- a/.packages/@do-md/core/src/editor/store/index.ts
+++ b/.packages/@do-md/core/src/editor/store/index.ts
@@ -66,6 +66,8 @@ import {
     blockTextOf,
     resolveOffsetToCursor,
     resolveSelectionTarget,
+    ResolvedRange,
+    SelectionRangeTarget,
     SelectionResult,
     SelectionTarget,
 } from "../model/selection/resolve";
@@ -1906,6 +1908,70 @@ export class EditorStore extends ZenithStore<StoreState> {
         }
         this.setCursorInfo_(start, end, CursorSource.Model, true);
         return { applied: true, start: resolved.start_, end: resolved.end_ };
+    }
+
+    /**
+     * Resolve absolute markdown ranges into block-level coordinates — the
+     * batch, side-effect-free companion of `setSelection`. Addressing is the
+     * replace family's, verbatim: offsets into the current `toMarkdown()`
+     * serialization. Pending speculative input is flushed first (the same
+     * hygiene as every sibling API), so ranges computed against a fresh
+     * `toMarkdown()` call always index the text this call resolves.
+     *
+     * Each range resolves independently to `{ start, end }` block coordinates
+     * (`{ uuid, offset }` — CursorSnapshot's vocabulary). Position them in the
+     * DOM the way remote cursors are drawn: `[data-render-id="${uuid}"]` +
+     * a text-node walk to the offset. A collapsed range (`end` omitted or
+     * equal to `start`) echoes the start anchor at both endpoints.
+     *
+     * An unresolvable entry — malformed, out of bounds, or a live tree that
+     * lost canonicality — yields `null` in its slot while the rest still
+     * resolve, the `resolveCursorPosition` contract: null means draw nothing.
+     * The result array always matches the argument list by position.
+     *
+     * Pure read: no cursor movement, no cursor event, no history entry, no
+     * ops. Built for decoration overlays that must paint every occurrence
+     * without disturbing the user's caret — search-match highlights, AI edit
+     * previews, external diff markers.
+     */
+    public resolveRanges(
+        ...ranges: SelectionRangeTarget[]
+    ): (ResolvedRange | null)[] {
+        this.applyPendingText_();
+        const map = buildTopLevelSourceMap(this.renderData_);
+        const parseOptions = {
+            codeTokenizer_: this._codeTokenizer_,
+            inlineRules_: this._inlineRules_,
+            imgGroupSeparators_: this._imgGroupSeparators_,
+        };
+        return ranges.map((range): ResolvedRange | null => {
+            const resolved = resolveSelectionTarget(range, map.docText_);
+            if ("reason_" in resolved) return null;
+            const start = resolveOffsetToCursor(
+                this.renderData_,
+                map,
+                resolved.start_,
+                "start",
+                parseOptions,
+            );
+            if (!start) return null;
+            if (resolved.end_ === resolved.start_) {
+                const anchor = { uuid: start.uuid, offset: start.offset };
+                return { start: anchor, end: { ...anchor } };
+            }
+            const end = resolveOffsetToCursor(
+                this.renderData_,
+                map,
+                resolved.end_,
+                "end",
+                parseOptions,
+            );
+            if (!end) return null;
+            return {
+                start: { uuid: start.uuid, offset: start.offset },
+                end: { uuid: end.uuid, offset: end.offset },
+            };
+        });
     }
 
     private _executeReplacePlan_(plan: ReplacePlan) {

--- a/.packages/@do-md/core/src/index.ts
+++ b/.packages/@do-md/core/src/index.ts
@@ -94,6 +94,8 @@ export type {
     SelectionSearchTarget,
     SelectionRangeTarget,
     SelectionResult,
+    ResolvedRange,
+    ResolvedRangeAnchor,
 } from "./editor/model/selection/resolve";
 
 // RenderData sync seam (for CRDT / persistence plugins; stable public keys, immune

--- a/.packages/@do-md/plugins/README.md
+++ b/.packages/@do-md/plugins/README.md
@@ -9,6 +9,7 @@ The kernel ships **mechanisms** (text replacement, selection addressing, an op s
 | Package | Description |
 |---|---|
 | [`commands`](./commands) | Named editing commands — heading/list/quote/code-block toggles, table & divider insertion, links, clear-formatting, a block-format state reader, and a keyboard shortcut binder. The `prosemirror-schema-list` of DoMD. |
+| [`search`](./search) | Headless find & replace — VSCode-semantics matching over the markdown source, a zenith store orchestrating navigate/replace through the replace family, and CSS Custom Highlight painting of every match. Bring your own widget UI. |
 | [`toc`](./toc) | Headless document outline (table of contents) — a flat heading list extracted from the model snapshot, kept in sync through the op stream, plus scroll spy and click-to-jump over the block uuid DOM contract. |
 
 More to come: realtime sync (Yjs binding), table renderer with row/column affordances, custom cursor overlay.

--- a/.packages/@do-md/plugins/search/.npmrc
+++ b/.packages/@do-md/plugins/search/.npmrc
@@ -1,0 +1,11 @@
+# Do not auto-install peerDependencies (npm 7+ default).
+#
+# This package lives inside the DoMD app repo, under apps/domd/.packages/. Its own
+# @do-md/core-react devDependency is deliberate (commands typecheck against the
+# published kernel declarations, exactly as a third-party consumer sees them - see
+# tsconfig.json), but the kernel's peers must not follow it down here: a react copy
+# under this directory would be reachable by "nearest node_modules" resolution and
+# give the app a second React instance. Peers resolve upwards, to the app's copy.
+#
+# Same setting, same class of reason, in ../../core/.npmrc and apps/domd/.npmrc.
+legacy-peer-deps=true

--- a/.packages/@do-md/plugins/search/README.md
+++ b/.packages/@do-md/plugins/search/README.md
@@ -1,0 +1,33 @@
+# @do-md/search
+
+Headless find & replace for [`@do-md/core-react`](https://www.npmjs.com/package/@do-md/core-react) — VSCode-semantics matching, a [zenith](https://www.npmjs.com/package/@do-md/zenith) store, and CSS Custom Highlight painting. Bring your own widget UI.
+
+## What it does
+
+- **Matching** (`compileQuery` / `findMatches`): literal or regex, case sensitivity, VSCode-style whole-word boundaries, match limit with explicit `limitHit`. The search space is the **markdown source** (`toMarkdown()`), the same coordinate space the kernel's replace family addresses — every match range feeds `setSelection` / `replaceRanges` / `resolveRanges` verbatim.
+- **State machine** (`SearchStore`): open/close, query & options, match count, wrap-around navigation, replace one / replace all. Replace-all is a single `replaceRanges` call — one undo step, fine-grained collab ops. Regex replacements expand `$1`/`$&`/`$$` from groups captured at scan time; preserve-case mirrors VSCode's AB toggle.
+- **Painting** (`bindSearchPainter`): every match painted through the CSS Custom Highlight API (`::highlight(domd-search)` / `::highlight(domd-search-active)`), anchored via the kernel's `resolveRanges` (>=0.11.7) and positioned the way remote cursors are drawn. No DOM mutation, no overlay rectangles. On kernels or browsers without the capability the engine still counts, navigates and replaces — it just paints nothing.
+
+Navigation deliberately never moves the model selection (that would fight the find input for focus and broadcast presence noise); the selection is placed once, on `close()`, landing the caret on the current match.
+
+## Usage sketch (React host)
+
+```tsx
+const search = useMemo(() => new SearchStore(), []);
+useEffect(() => search.attach(editorStore), [search, editorStore]);
+useEffect(
+    () => bindSearchPainter(search, editorStore, editorContainerEl),
+    [search, editorStore, editorContainerEl],
+);
+```
+
+Style the highlights in your CSS:
+
+```css
+::highlight(domd-search) { background-color: rgb(180 160 60 / 0.35); }
+::highlight(domd-search-active) { background-color: rgb(200 130 60 / 0.6); }
+```
+
+## License
+
+MIT.

--- a/.packages/@do-md/plugins/search/package-lock.json
+++ b/.packages/@do-md/plugins/search/package-lock.json
@@ -1,0 +1,1722 @@
+{
+    "name": "@do-md/search",
+    "version": "0.1.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@do-md/search",
+            "version": "0.1.0",
+            "license": "MIT",
+            "devDependencies": {
+                "@do-md/core-react": "^0.11.6",
+                "@do-md/zenith": "^2.0.3",
+                "@microsoft/api-extractor": "^7.58.13",
+                "typescript": "^5.6.0",
+                "vite": "^7.2.2"
+            },
+            "peerDependencies": {
+                "@do-md/core-react": ">=0.11.6",
+                "@do-md/zenith": ">=2.0.3"
+            }
+        },
+        "node_modules/@do-md/core-react": {
+            "version": "0.11.6",
+            "resolved": "https://registry.npmjs.org/@do-md/core-react/-/core-react-0.11.6.tgz",
+            "integrity": "sha512-d8XSBtZ4XtWf65Rrt8GPGk2uGJnsx5mqIQldylvXAO/BxpomDfg4y+ksSylp1tPkJVenxMt6759Pn14GOSNkMA==",
+            "dev": true,
+            "license": "GPL-3.0-only",
+            "peerDependencies": {
+                "immer": "^10.2.0 || ^11",
+                "react": ">=18.0.0",
+                "react-dom": ">=18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "immer": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/@do-md/zenith": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@do-md/zenith/-/zenith-2.0.3.tgz",
+            "integrity": "sha512-NOEk001aKGmZQi5/WtdK5IhFo8sfmDDZAQeth6w+Da1QVliebnEbhR8TJTUeFnZRvMLnQH+8MM0eUe4vUgINkw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "immer": "^10.2.0",
+                "react": ">=18.0.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+            "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+            "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+            "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+            "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+            "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+            "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+            "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+            "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+            "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+            "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+            "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+            "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+            "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+            "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+            "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+            "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+            "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+            "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+            "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+            "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+            "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@microsoft/api-extractor": {
+            "version": "7.59.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.59.0.tgz",
+            "integrity": "sha512-KDYV8kSVjmG8JJWVg1f1aKxteNG1IQ44D07Rjhlcci8wlqrSFNhUfgv7dJhwT0W2h3NDIL5Vz2f+/DfO4OpDHw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/api-extractor-model": "7.33.11",
+                "@microsoft/tsdoc": "~0.16.0",
+                "@microsoft/tsdoc-config": "~0.18.1",
+                "@rushstack/node-core-library": "5.24.0",
+                "@rushstack/rig-package": "0.7.3",
+                "@rushstack/terminal": "0.24.3",
+                "@rushstack/ts-command-line": "5.3.13",
+                "diff": "~8.0.2",
+                "minimatch": "10.2.3",
+                "resolve": "~1.22.1",
+                "semver": "~7.7.4",
+                "source-map": "~0.6.1",
+                "typescript": "5.9.3"
+            },
+            "bin": {
+                "api-extractor": "bin/api-extractor"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            }
+        },
+        "node_modules/@microsoft/api-extractor-model": {
+            "version": "7.33.11",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.11.tgz",
+            "integrity": "sha512-iDu1AtuRC2Z8XVs2SieZieVavF1FXPBX1C9pMexJh8Dx/Dd/3ZZ4nRQp/PU2Vk2rUHWuBz1wOyL4DcuhVnBXwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/tsdoc": "~0.16.0",
+                "@microsoft/tsdoc-config": "~0.18.1",
+                "@rushstack/node-core-library": "5.24.0"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            }
+        },
+        "node_modules/@microsoft/tsdoc": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+            "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@microsoft/tsdoc-config": {
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+            "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/tsdoc": "0.16.0",
+                "ajv": "~8.18.0",
+                "jju": "~1.4.0",
+                "resolve": "~1.22.2"
+            }
+        },
+        "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+            "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^22.20 || ^24.12 || >=25"
+            }
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.0.tgz",
+            "integrity": "sha512-70TeIFezKKy65LgAVyQh+w94/gjWhvPWaLaGGeMEgVrPkQhuj/M5bAYYZzIFUj9Y69oHyTm5Um/R6gcLh4A8JA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.0.tgz",
+            "integrity": "sha512-YC86tYIHK6M1IV+wbzO+Bxk8RCBr6ZyWYgWxUCzaZD8mc8rrFoIJDNzDrkHBYRc/wKdrsIXmm6/F7NzrAO+OrA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.0.tgz",
+            "integrity": "sha512-oI+ECtUcli0y0fi4xpW82GdPIXdTkI8G8DSjG2LRuw09fPAGykaWYH/hXxiKuTxiAjiPSTIIuYUqof5Z2hShWw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.0.tgz",
+            "integrity": "sha512-NwV+1s7TiKrMe4owHyKB/dTLD7ZJD0YEBEhIz+hvav1Cu1GReJjF+rsdNwjzENQeIAbE/CoNiaAc5Vz2h5DPAA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.0.tgz",
+            "integrity": "sha512-tWtHBTu5gOPK4u4Urtk4qAHW3zZ9rQAmbssO8gp7ELvGTGI3aCiq6NqyTQ0PCIg7KbHJF2UkGDDs77YZGxfjCA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.0.tgz",
+            "integrity": "sha512-2qPoJiwTvtHQ27NnYvTnsgk8laXWYuVmNESG8WFZBcEPKLfZ3I27qBJarjVRQtwGeYyRfq5ZowHXih9lm2BItw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.0.tgz",
+            "integrity": "sha512-FQwsTRvLNuHoTdICABJQfbPUSEueISGmnpT06tXTMpfprf5NiKLSXKA0A+w45wJnCmZAnzgqBwbt6ARFuyOi5w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.0.tgz",
+            "integrity": "sha512-BBVTXziw8mY1a4ZbWME9tZyfzqXCDPqaC7Z3heQ29p5dkvXzwL0NwelO8zLa8c3RBKvl3YTuSnBgsBhYBtwjIw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.0.tgz",
+            "integrity": "sha512-w2Iyy9+RqKwx3d9qWMKsJg0FfRBsY0/pXNv0mCQ3ueRvJI6+QAScfD4nrMlzFLs2HNVW6Ew+mtZfDl9b7Ew5/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.0.tgz",
+            "integrity": "sha512-YK++KtrFRHYE0P6/RtYEAy9t8F37znP+K03RrIuLPYOL6SVlObRumf/0OE4V/h63xL9DwkWbNssZfmA9hawuDA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.0.tgz",
+            "integrity": "sha512-aBfOG6fP7YkkPmTqPwufRJeFyz7WPpECv9XNbnsk9+vg7rxdih0lbtEel7jcRng4LZrrmU3FfitCFyEj4BWDWg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.0.tgz",
+            "integrity": "sha512-LGaHEOeHNAag9VuS1Crs5DFg4RrU9MPi2nVnNJk9DTePx/B6RRYKVmrIXt2h7YOJlwjaFJ6lwtFDliZxScTLrQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.0.tgz",
+            "integrity": "sha512-jClvk+J0FC3b7Udvegiw5/4hErbHtmsNsQgENnKXDWtNCJXsJYZH5WURvu7imDOO38xYml24eeh5x3A04ppwCw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.0.tgz",
+            "integrity": "sha512-0OJlaGK+8+B777Ql5okIpD7ua5Ro9+VB9Ve0OKa28OQJZ1RbuUBVNHK/e3pr4BROqsyPl1JrPO1ZxJseCNffcA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.0.tgz",
+            "integrity": "sha512-Ygsx+HoNH7afwi1bTIXbnTvVnsO+zurPLSYxybV1hHFVU72OWOCl6v05ql/z0hkpAPx+DK7Kn9Bi7MayCcjLTA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.0.tgz",
+            "integrity": "sha512-pDQxtMGb+OvG3fLwR2OkZlSd47hW+kWg4BYMG/++sR6RqorQccwPTDsxda5hPwiIeIErAnCF9ma3SAU06bdQtQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.0.tgz",
+            "integrity": "sha512-0BnUG9mS8I4SSHr3XsxVhuCMEiu+rX61xxZF5vujso4LaiAGFZFxvDjg6Xn6tLPNTUAfuCvQYas4LMQMVsKRSQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.0.tgz",
+            "integrity": "sha512-Adu/VttB1dpPNW+FEacrZ+xVm9tFty84+RrFzsqlFaPxoJB+9XXyDGtp5dCOoBwGBIEVH0To7lExFXEx0BIF4A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.0.tgz",
+            "integrity": "sha512-NQ3bDvjUbFKmP23671xUlXtKmqVsUBd6M4PQCvbmNtOy06hnQIdKHy8oG/6S3R/S6He1JgPk6A5VT+prAJMYEw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.0.tgz",
+            "integrity": "sha512-u2eDAl4+0aFvA13GxlGBtTI3SS3sdgwgtV0HyjZ0QaQVCgNE+jqNGey+GtxWiq+wxr/UycAx/OnfJzApCFamvA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.0.tgz",
+            "integrity": "sha512-XvRb5vfW3wAZQ+ZUG21AnHHDKtNcw99eigzEhjr//NZ3u7SoBaPP0seSc7FgP7p1epAEdAoZckMW9WY/+4w70w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.0.tgz",
+            "integrity": "sha512-iZPmniy4kNBf5yo2RezbkYNNK5HPbXE9+g+twnbqSng7dtLEJy1SKoxiE/ni4FDacjyuZpEeb9U054N4EoKHYw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.0.tgz",
+            "integrity": "sha512-mFBBd+LF37fnE8JnYUOH+imj0aPFPK30vpar4ehJkgnLj9sZn8ZxiRENmLtgIwxK7TC8klF6N57fxdNBwQoqOA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.0.tgz",
+            "integrity": "sha512-ujeqEY3B+zbGn3Z4Q03cUBG/LGWnBJncVT36WER31LcOsQk9+1dmINKKtvmmfChUvRbK1G0R8OhMWFgHgaZtAw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.0.tgz",
+            "integrity": "sha512-hncn90N4sOky0L2LKE5oESKLbxCPeVo4eLA2LSMoDzM+879ml4WSr+Rr4DWknNIVVvS1Hirkc9hx02W6YxS8rQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rushstack/node-core-library": {
+            "version": "5.24.0",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.24.0.tgz",
+            "integrity": "sha512-g/Z47ZwARn/VkTnHcyJslrR26erRf1G5JbqPlfGZGBCrOcrEt8fTQXXDVhUDDNl/g/v3TXI1dNiAAT5FEks8BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "~8.20.0",
+                "ajv-draft-04": "~1.0.0",
+                "ajv-formats": "~3.0.1",
+                "fs-extra": "~11.3.0",
+                "import-lazy": "~4.0.0",
+                "jju": "~1.4.0",
+                "resolve": "~1.22.1",
+                "semver": "~7.7.4"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "peerDependencies": {
+                "@types/node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@rushstack/problem-matcher": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
+            "integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rushstack/rig-package": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
+            "integrity": "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jju": "~1.4.0",
+                "resolve": "~1.22.1"
+            }
+        },
+        "node_modules/@rushstack/terminal": {
+            "version": "0.24.3",
+            "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.3.tgz",
+            "integrity": "sha512-KxphDhPGC4xDrKg8O4yrWCEpPMi87aJc1iycXqMVh1dLgV0M34hiH9ZTgWjBRmcrT/OIHoOeWf48npcQFzgp+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rushstack/node-core-library": "5.24.0",
+                "@rushstack/problem-matcher": "0.2.1",
+                "supports-color": "~8.1.1"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "peerDependencies": {
+                "@types/node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rushstack/ts-command-line": {
+            "version": "5.3.13",
+            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.13.tgz",
+            "integrity": "sha512-+jNbxhh8CkrZYxMk9X3GRYM2+Myr1xCCj+eHbJ9Vp+PCdNHS0TUl5QQFT6UbM/aTFRCzs5jiBTKYzBRpe5uYbQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rushstack/terminal": "0.24.3",
+                "@types/argparse": "1.0.38",
+                "argparse": "~1.0.9",
+                "string-argv": "~0.3.1"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            }
+        },
+        "node_modules/@types/argparse": {
+            "version": "1.0.38",
+            "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+            "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ajv": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-draft-04": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/diff": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+            "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+            "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.2",
+                "@esbuild/android-arm": "0.28.2",
+                "@esbuild/android-arm64": "0.28.2",
+                "@esbuild/android-x64": "0.28.2",
+                "@esbuild/darwin-arm64": "0.28.2",
+                "@esbuild/darwin-x64": "0.28.2",
+                "@esbuild/freebsd-arm64": "0.28.2",
+                "@esbuild/freebsd-x64": "0.28.2",
+                "@esbuild/linux-arm": "0.28.2",
+                "@esbuild/linux-arm64": "0.28.2",
+                "@esbuild/linux-ia32": "0.28.2",
+                "@esbuild/linux-loong64": "0.28.2",
+                "@esbuild/linux-mips64el": "0.28.2",
+                "@esbuild/linux-ppc64": "0.28.2",
+                "@esbuild/linux-riscv64": "0.28.2",
+                "@esbuild/linux-s390x": "0.28.2",
+                "@esbuild/linux-x64": "0.28.2",
+                "@esbuild/netbsd-arm64": "0.28.2",
+                "@esbuild/netbsd-x64": "0.28.2",
+                "@esbuild/openbsd-arm64": "0.28.2",
+                "@esbuild/openbsd-x64": "0.28.2",
+                "@esbuild/openharmony-arm64": "0.28.2",
+                "@esbuild/sunos-x64": "0.28.2",
+                "@esbuild/win32-arm64": "0.28.2",
+                "@esbuild/win32-ia32": "0.28.2",
+                "@esbuild/win32-x64": "0.28.2"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+            "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "11.3.6",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+            "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/import-lazy": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+            "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/jju": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+            "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jsonfile": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "10.2.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+            "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.17",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "4.63.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.0.tgz",
+            "integrity": "sha512-T5vnZ2y4QqC3/4P+w2+JO+Q/OVdnPsv4XcSYJYMEn0R9/jjl5AgLwO9LAZMzP2lN71O6pypn91rB7lDstUkfrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.9"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+                "@rollup/rollup-android-arm-eabi": "4.63.0",
+                "@rollup/rollup-android-arm64": "4.63.0",
+                "@rollup/rollup-darwin-arm64": "4.63.0",
+                "@rollup/rollup-darwin-x64": "4.63.0",
+                "@rollup/rollup-freebsd-arm64": "4.63.0",
+                "@rollup/rollup-freebsd-x64": "4.63.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.63.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.63.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.63.0",
+                "@rollup/rollup-linux-arm64-musl": "4.63.0",
+                "@rollup/rollup-linux-loong64-gnu": "4.63.0",
+                "@rollup/rollup-linux-loong64-musl": "4.63.0",
+                "@rollup/rollup-linux-ppc64-gnu": "4.63.0",
+                "@rollup/rollup-linux-ppc64-musl": "4.63.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.63.0",
+                "@rollup/rollup-linux-riscv64-musl": "4.63.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.63.0",
+                "@rollup/rollup-linux-x64-gnu": "4.63.0",
+                "@rollup/rollup-linux-x64-musl": "4.63.0",
+                "@rollup/rollup-openbsd-x64": "4.63.0",
+                "@rollup/rollup-openharmony-arm64": "4.63.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.63.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.63.0",
+                "@rollup/rollup-win32-x64-gnu": "4.63.0",
+                "@rollup/rollup-win32-x64-msvc": "4.63.0",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/string-argv": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+            "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.19"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/vite": {
+            "version": "7.3.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+            "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "lightningcss": "^1.21.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        }
+    }
+}

--- a/.packages/@do-md/plugins/search/package.json
+++ b/.packages/@do-md/plugins/search/package.json
@@ -1,0 +1,50 @@
+{
+    "name": "@do-md/search",
+    "version": "0.1.0",
+    "description": "Headless find & replace engine for the @do-md/core-react editor — VSCode-semantics matching, a zenith store, and CSS Custom Highlight painting",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+        }
+    },
+    "files": [
+        "dist",
+        "src"
+    ],
+    "scripts": {
+        "build": "vite build && node scripts/build-types.mjs",
+        "typecheck": "tsc --noEmit",
+        "prepublishOnly": "rm -rf dist && npm run build"
+    },
+    "peerDependencies": {
+        "@do-md/core-react": ">=0.11.6",
+        "@do-md/zenith": ">=2.0.3"
+    },
+    "devDependencies": {
+        "@do-md/core-react": "^0.11.6",
+        "@do-md/zenith": "^2.0.3",
+        "@microsoft/api-extractor": "^7.58.13",
+        "typescript": "^5.6.0",
+        "vite": "^7.2.2"
+    },
+    "sideEffects": false,
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/do-md/domd.git",
+        "directory": ".packages/@do-md/plugins/search"
+    },
+    "keywords": [
+        "domd",
+        "markdown",
+        "editor",
+        "find",
+        "replace",
+        "search",
+        "highlight"
+    ]
+}

--- a/.packages/@do-md/plugins/search/scripts/build-types.mjs
+++ b/.packages/@do-md/plugins/search/scripts/build-types.mjs
@@ -1,0 +1,67 @@
+// Generates the declarations we publish: dist/index.d.ts, one self-contained file.
+//
+// Plain `tsc --declaration` would emit one .d.ts per source file, cross-referencing each
+// other with the same extensionless specifiers the sources use (see vite.config.ts for
+// why they are extensionless). Bundler-resolution consumers cope with that; a consumer on
+// node16/nodenext resolution does not, and gets "cannot find module ./target" on a
+// package that otherwise works. Rolling the tree up into a single file removes the whole
+// class of problem: the published declarations contain no relative specifiers at all.
+//
+// Same two-step shape as the kernel's scripts/build-types.mjs (tsc -> api-extractor).
+import { spawnSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Extractor, ExtractorConfig } from "@microsoft/api-extractor";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const tmpDir = resolve(rootDir, ".types-tmp");
+const entry = resolve(tmpDir, "index.d.ts");
+const outFile = resolve(rootDir, "dist/index.d.ts");
+
+rmSync(tmpDir, { recursive: true, force: true });
+
+// 1) Emit the declarations (rootDir is src/, so they land flat in .types-tmp/)
+const tsc = spawnSync(
+    "npx",
+    ["tsc", "-p", "tsconfig.json", "--emitDeclarationOnly", "--outDir", ".types-tmp"],
+    { cwd: rootDir, stdio: "inherit" },
+);
+if (tsc.status !== 0) {
+    console.error("\n\u2717 Failed to emit the type declarations (tsc)");
+    process.exit(tsc.status ?? 1);
+}
+if (!existsSync(entry)) {
+    console.error(`\n\u2717 Declaration entry not found: ${entry}`);
+    process.exit(1);
+}
+
+// 2) Roll it up into a single file. @do-md/core-react stays a bare import: it is a peer
+//    dependency, not something to inline.
+const config = ExtractorConfig.prepare({
+    configObjectFullPath: undefined,
+    packageJsonFullPath: resolve(rootDir, "package.json"),
+    configObject: {
+        projectFolder: rootDir,
+        mainEntryPointFilePath: entry,
+        compiler: { tsconfigFilePath: resolve(rootDir, "scripts/tsconfig.types.json") },
+        dtsRollup: { enabled: true, untrimmedFilePath: outFile },
+        apiReport: { enabled: false },
+        docModel: { enabled: false },
+        tsdocMetadata: { enabled: false },
+        messages: {
+            compilerMessageReporting: { default: { logLevel: "none" } },
+            extractorMessageReporting: { default: { logLevel: "none" } },
+            tsdocMessageReporting: { default: { logLevel: "none" } },
+        },
+    },
+});
+const result = Extractor.invoke(config, { localBuild: true, showVerboseMessages: false });
+rmSync(tmpDir, { recursive: true, force: true });
+if (!result.succeeded) {
+    console.error(
+        `\n\u2717 Failed to roll up the type declarations (api-extractor): ${result.errorCount} error`,
+    );
+    process.exit(1);
+}
+console.log("\u2713 dist/index.d.ts");

--- a/.packages/@do-md/plugins/search/scripts/tsconfig.types.json
+++ b/.packages/@do-md/plugins/search/scripts/tsconfig.types.json
@@ -1,0 +1,13 @@
+{
+    "//": "For the api-extractor declaration rollup only (see scripts/build-types.mjs). It compiles the declaration tree tsc just emitted into .types-tmp, never src — the moment the rollup resolves back to .ts sources api-extractor crashes midway.",
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
+        "strict": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true
+    },
+    "files": ["../.types-tmp/index.d.ts"]
+}

--- a/.packages/@do-md/plugins/search/scripts/verify-search/entry.ts
+++ b/.packages/@do-md/plugins/search/scripts/verify-search/entry.ts
@@ -1,0 +1,477 @@
+/**
+ * Headless assertion matrix for @do-md/search. Run from the package root:
+ *   sh scripts/verify-search/run.sh
+ *
+ * Two layers:
+ *   MATCHER — pure semantics: literal escaping, case folding, u-flag
+ *     fallback, non-overlapping scan, zero-length skip, multiline anchors,
+ *     match limit + limitHit, whole-word boundaries (separator table, CJK),
+ *     replacement expansion ($n/$&/$$/two-digit/escapes), preserve-case.
+ *   STORE — SearchStore driving the REAL kernel EditorStore (headless, no
+ *     DOM): open/prefill/fromCursor anchoring, navigation wrap, option
+ *     rescans, regex error surfacing, replace-current advance semantics,
+ *     replace-all as ONE undo step, preserve-case + regex groups end to end,
+ *     external-edit rescan with keepNear, close() landing the model
+ *     selection, detach reset, resolveMatchAnchors against the real
+ *     resolveRanges (cap + active tail slot).
+ */
+import {
+    compileQuery,
+    expandReplacement,
+    findMatches,
+    preserveCase,
+    SearchMatch,
+    SearchOptions,
+} from "../../src/matcher";
+import { SearchStore } from "../../src/store";
+import { EditorStore } from "../../../../core/src/editor/store";
+
+/* eslint-disable no-console */
+const rawLog = console.log.bind(console);
+console.log = () => {};
+console.time = () => {};
+console.timeEnd = () => {};
+
+let passes = 0;
+let failures = 0;
+const check = (name: string, cond: boolean, detail?: unknown) => {
+    if (cond) {
+        passes += 1;
+    } else {
+        failures += 1;
+        rawLog(`✗ ${name}`, detail !== undefined ? JSON.stringify(detail) : "");
+    }
+};
+
+const OPTS = (over: Partial<SearchOptions> = {}): SearchOptions => ({
+    caseSensitive: false,
+    wholeWord: false,
+    regex: false,
+    ...over,
+});
+
+const scan = (
+    text: string,
+    query: string,
+    options: SearchOptions = OPTS(),
+    limit?: number,
+) => findMatches(text, compileQuery(query, options), options, limit);
+
+// ===========================================================================
+// MATCHER
+// ===========================================================================
+
+// --- compileQuery -----------------------------------------------------------
+check("compile: empty query", compileQuery("", OPTS()).kind === "empty");
+check(
+    "compile: literal dot is escaped",
+    scan("a.b axb", "a.b").matches.length === 1 &&
+        scan("a.b axb", "a.b").matches[0].start === 0,
+);
+check(
+    "compile: invalid regex reports error",
+    compileQuery("ta(ri", OPTS({ regex: true })).kind === "error",
+);
+check(
+    "compile: u-flag fallback keeps sloppy escapes working",
+    (() => {
+        const compiled = compileQuery("\\q", OPTS({ regex: true }));
+        return (
+            compiled.kind === "ok" &&
+            scan("a q b", "\\q", OPTS({ regex: true })).matches.length === 1
+        );
+    })(),
+);
+
+// --- findMatches ------------------------------------------------------------
+check(
+    "scan: case-insensitive by default",
+    scan("Foo foo FOO", "foo").matches.length === 3,
+);
+check(
+    "scan: case-sensitive option",
+    scan("Foo foo FOO", "foo", OPTS({ caseSensitive: true })).matches
+        .length === 1,
+);
+check(
+    "scan: non-overlapping left to right",
+    scan("aaaa", "aa").matches.map((m) => m.start).join(",") === "0,2",
+);
+check(
+    "scan: zero-length matches skipped, scan terminates",
+    scan("bbb", "a*", OPTS({ regex: true })).matches.length === 0,
+);
+check(
+    "scan: zero-length skip keeps real matches",
+    scan("xxyx", "x*", OPTS({ regex: true })).matches.map(
+        (m) => `${m.start}-${m.end}`,
+    ).join(",") === "0-2,3-4",
+);
+check(
+    "scan: multiline caret addresses line starts",
+    scan("a\nb\nba", "^b", OPTS({ regex: true })).matches.length === 2,
+);
+{
+    const limited = scan("x x x", "x", OPTS(), 2);
+    check(
+        "scan: limit caps matches and reports limitHit",
+        limited.matches.length === 2 && limited.limitHit === true,
+    );
+    const exact = scan("x x", "x", OPTS(), 2);
+    check("scan: limit not hit when exact", exact.limitHit === false);
+}
+check(
+    "scan: regex captures groups at scan time",
+    (() => {
+        const m = scan("ab cd", "(a)(b)", OPTS({ regex: true })).matches[0];
+        return !!m.groups && m.groups.join(",") === "ab,a,b";
+    })(),
+);
+
+// --- whole word -------------------------------------------------------------
+const WW = OPTS({ wholeWord: true });
+check(
+    "word: separator-delimited matches only",
+    scan("item items item.", "item", WW).matches.length === 2,
+);
+check("word: substring rejected", scan("nitems", "item", WW).matches.length === 0);
+check(
+    "word: match's own separator edge counts as boundary",
+    scan("x (foo) y", "(foo)", WW).matches.length === 1,
+);
+check(
+    "word: CJK neighbour is a word character (VSCode parity)",
+    scan("词汇 词", "词", WW).matches.length === 1 &&
+        scan("词汇 词", "词", WW).matches[0].start === 3,
+);
+
+// --- expandReplacement ------------------------------------------------------
+const M = (groups: string[]): SearchMatch => ({
+    start: 0,
+    end: groups[0]?.length ?? 0,
+    groups,
+});
+check(
+    "expand: numbered groups",
+    expandReplacement("$2-$1", M(["ab", "a", "b"])) === "b-a",
+);
+check("expand: $& whole match", expandReplacement("[$&]", M(["ab", "a", "b"])) === "[ab]");
+check("expand: $$ literal dollar", expandReplacement("$$1", M(["ab", "a", "b"])) === "$1");
+check("expand: $0 whole match", expandReplacement("$0", M(["ab", "a", "b"])) === "ab");
+check(
+    "expand: missing group stays literal",
+    expandReplacement("$5", M(["ab", "a", "b"])) === "$5",
+);
+check(
+    "expand: two-digit group when it exists",
+    expandReplacement("$10", M(["m", ...Array.from({ length: 10 }, (_, i) => `g${i + 1}`)])) ===
+        "g10",
+);
+check(
+    "expand: two-digit falls back to one digit + literal",
+    expandReplacement("$10", M(["ab", "a", "b"])) === "a0",
+);
+check(
+    "expand: escapes",
+    expandReplacement("a\\nb\\tc\\\\d", M(["m"])) === "a\nb\tc\\d",
+);
+check(
+    "expand: unknown escape stays literal",
+    expandReplacement("a\\qb", M(["m"])) === "a\\qb",
+);
+
+// --- preserveCase -----------------------------------------------------------
+check("case: UPPER", preserveCase("HELLO", "world") === "WORLD");
+check("case: lower", preserveCase("hello", "World") === "world");
+check("case: Title", preserveCase("Hello", "world") === "World");
+check("case: no cased letters passes through", preserveCase("123", "world") === "world");
+check("case: empty replacement", preserveCase("Hello", "") === "");
+check("case: empty match", preserveCase("", "world") === "world");
+
+// ===========================================================================
+// STORE — against the real kernel EditorStore, headless
+// ===========================================================================
+
+const CORPUS = [
+    "# Tauri Notes",
+    "",
+    "tauri is great. TAURI wins. Tauri again.",
+    "",
+    "- item tauri one",
+    "- item two",
+    "",
+    "| name | value |",
+    "| ---- | ----- |",
+    "| tauri | 42 |",
+    "",
+    "```js",
+    "const tauri = 1;",
+    "```",
+].join("\n");
+
+const makePair = (initMd: string = CORPUS) => {
+    const editor = new EditorStore({ editable: true, initMd });
+    const search = new SearchStore();
+    search.attach(editor);
+    return { editor, search };
+};
+
+const occurrenceStarts = (doc: string, needle: string): number[] => {
+    const out: number[] = [];
+    let from = 0;
+    for (;;) {
+        const at = doc.toLowerCase().indexOf(needle.toLowerCase(), from);
+        if (at === -1) return out;
+        out.push(at);
+        from = at + needle.length;
+    }
+};
+
+// --- open / scan / navigation ----------------------------------------------
+{
+    const { editor, search } = makePair();
+    const doc = editor.toMarkdown();
+    const expected = occurrenceStarts(doc, "tauri");
+
+    search.openFind();
+    check("store: opens", search.state.open === true);
+    check("store: empty query scans nothing", search.state.matches.length === 0);
+
+    search.setQuery("tauri");
+    check(
+        "store: match count equals naive scan",
+        search.state.matches.length === expected.length,
+        { got: search.state.matches.length, want: expected.length },
+    );
+    check(
+        "store: match offsets equal naive scan",
+        search.state.matches.map((m) => m.start).join(",") ===
+            expected.join(","),
+    );
+    check("store: first match active", search.state.activeIndex === 0);
+
+    search.findNext();
+    check("store: next advances", search.state.activeIndex === 1);
+    search.findPrevious();
+    search.findPrevious();
+    check(
+        "store: previous wraps to last",
+        search.state.activeIndex === search.state.matches.length - 1,
+    );
+    search.findNext();
+    check("store: next wraps to first", search.state.activeIndex === 0);
+
+    // Option rescan
+    search.setOption("caseSensitive", true);
+    check(
+        "store: case-sensitive rescan",
+        search.state.matches.length === 4,
+        search.state.matches.length,
+    );
+    search.setOption("caseSensitive", false);
+
+    // Regex error surfacing
+    search.setOption("regex", true);
+    search.setQuery("ta(ri");
+    check(
+        "store: regex error surfaces, zero matches",
+        search.state.queryError !== null && search.state.matches.length === 0,
+    );
+    search.setQuery("ta.ri");
+    check(
+        "store: regex error clears",
+        search.state.queryError === null &&
+            search.state.matches.length === expected.length,
+    );
+}
+
+// --- prefill + fromCursor anchoring -----------------------------------------
+{
+    const { editor, search } = makePair();
+    const doc = editor.toMarkdown();
+    const upperAt = doc.indexOf("TAURI");
+    editor.setSelection({ start: upperAt, end: upperAt + 5 });
+
+    search.openFind();
+    check("store: selection prefills query", search.state.query === "TAURI");
+    const active = search.state.matches[search.state.activeIndex];
+    check(
+        "store: active anchors at the caret's match",
+        active?.start === upperAt,
+        { active, upperAt },
+    );
+    search.close();
+
+    // Multi-line selections must NOT prefill
+    const crossStart = doc.indexOf("Tauri again.");
+    editor.setSelection({ start: crossStart, end: doc.indexOf("item two") });
+    search.openFind();
+    check(
+        "store: multi-line selection does not prefill",
+        search.state.query === "TAURI",
+    );
+}
+
+// --- replace current: advance-past semantics --------------------------------
+{
+    const { editor, search } = makePair("b b b");
+    search.openFind();
+    search.setQuery("b");
+    search.setReplacement("bb");
+    search.replaceCurrent();
+    check("store: replace-current applies", editor.toMarkdown() === "bb b b");
+    const active = search.state.matches[search.state.activeIndex];
+    check(
+        "store: active advances past the inserted text",
+        !!active && active.start >= 2,
+        { active },
+    );
+}
+
+// --- replace current + undo -------------------------------------------------
+{
+    const { editor, search } = makePair();
+    const original = editor.toMarkdown();
+    search.openFind();
+    search.setQuery("tauri");
+    search.setReplacement("cargo");
+    search.replaceCurrent();
+    check(
+        "store: replace-current rewrites the heading",
+        editor.toMarkdown().startsWith("# cargo Notes"),
+        editor.toMarkdown().split("\n")[0],
+    );
+    editor.undo();
+    check("store: one undo restores replace-current", editor.toMarkdown() === original);
+}
+
+// --- replace all: preserve case, ONE undo step ------------------------------
+{
+    const { editor, search } = makePair();
+    const original = editor.toMarkdown();
+    search.openFind();
+    search.setQuery("tauri");
+    search.setReplacement("cargo");
+    search.setOption("preserveCase", true);
+    search.replaceAll();
+    const after = editor.toMarkdown();
+    check(
+        "store: preserve-case replace-all",
+        after.startsWith("# Cargo Notes") &&
+            after.includes("cargo is great. CARGO wins. Cargo again.") &&
+            !/tauri/i.test(after),
+        after.split("\n").slice(0, 3),
+    );
+    check("store: rescan empties matches", search.state.matches.length === 0);
+    editor.undo();
+    check("store: ONE undo restores replace-all", editor.toMarkdown() === original);
+}
+
+// --- regex group replacement end to end -------------------------------------
+{
+    const { editor, search } = makePair();
+    const original = editor.toMarkdown();
+    search.openFind();
+    search.setOption("regex", true);
+    search.setQuery("(item) (\\w+)");
+    search.setReplacement("$2 $1");
+    check("store: regex finds both list rows", search.state.matches.length === 2);
+    search.replaceAll();
+    const lines = editor.toMarkdown().split("\n").filter((l) => l.startsWith("- "));
+    check(
+        "store: group swap applied",
+        lines.join("|") === "- tauri item one|- two item",
+        lines,
+    );
+    editor.undo();
+    check("store: one undo restores regex replace-all", editor.toMarkdown() === original);
+}
+
+// --- external edits rescan with keepNear ------------------------------------
+{
+    const { editor, search } = makePair();
+    search.openFind();
+    search.setQuery("tauri");
+    search.findNext(); // active = #1 (second match)
+    const before = search.state.matches.length;
+    const activeStart = search.state.matches[search.state.activeIndex].start;
+    const len = editor.toMarkdown().length;
+    editor.replaceRanges({ start: len, end: len, text: "\n\ntauri tail" });
+    check(
+        "store: external edit rescans",
+        search.state.matches.length === before + 1,
+        { before, after: search.state.matches.length },
+    );
+    const reanchored = search.state.matches[search.state.activeIndex];
+    check(
+        "store: active re-anchors near previous offset",
+        reanchored?.start === activeStart,
+        { reanchored, activeStart },
+    );
+}
+
+// --- close lands the model selection ----------------------------------------
+{
+    const { editor, search } = makePair();
+    search.openFind();
+    search.setQuery("TAURI");
+    search.setOption("caseSensitive", true);
+    search.close();
+    check("store: close resets state", search.state.open === false && search.state.matches.length === 0);
+    check(
+        "store: close lands selection on the match",
+        editor.getSelectionState().selected_text === "TAURI",
+        editor.getSelectionState().selected_text,
+    );
+}
+
+// --- resolveMatchAnchors against the real kernel ----------------------------
+{
+    const { editor, search } = makePair();
+    search.openFind();
+    search.setQuery("tauri");
+    const anchors = search.resolveMatchAnchors();
+    check(
+        "store: every match resolves to block anchors",
+        anchors.length === search.state.matches.length &&
+            anchors.every((a) => a !== null && !!a.start.uuid && !!a.end.uuid),
+        anchors.length,
+    );
+    // Cap: 2 resolved + the active match riding in a tail slot
+    search.findNext();
+    search.findNext();
+    search.findNext(); // activeIndex = 3, beyond a cap of 2
+    const capped = search.resolveMatchAnchors(2);
+    check(
+        "store: cap appends the active match as a tail slot",
+        capped.length === 3 && capped.every((a) => a !== null),
+        capped.length,
+    );
+    const activeMatch = search.state.matches[3];
+    const sel = editor.setSelection({ start: activeMatch.start, end: activeMatch.end });
+    const snap = editor.getCursorSnapshot();
+    check(
+        "store: tail slot equals setSelection placement of the active match",
+        sel.applied === true &&
+            capped[2]?.start.uuid === snap.start?.uuid &&
+            capped[2]?.start.offset === snap.start?.offset,
+        { tail: capped[2], snap: snap.start },
+    );
+}
+
+// --- detach resets ----------------------------------------------------------
+{
+    const { search } = makePair();
+    search.openFind();
+    search.setQuery("tauri");
+    search.detach();
+    check(
+        "store: detach resets to initial state",
+        search.state.open === false &&
+            search.state.query === "" &&
+            search.state.matches.length === 0,
+    );
+}
+
+rawLog(`@do-md/search verification: ${passes} passed, ${failures} failed`);
+if (failures > 0) process.exit(1);

--- a/.packages/@do-md/plugins/search/scripts/verify-search/run.sh
+++ b/.packages/@do-md/plugins/search/scripts/verify-search/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# @do-md/search headless verification: matcher semantics + SearchStore driving
+# the real kernel EditorStore. Run from the package root:
+#   sh scripts/verify-search/run.sh
+cd "$(dirname "$0")/../.." || exit 1
+npx esbuild scripts/verify-search/entry.ts \
+  --bundle \
+  --format=esm \
+  --platform=node \
+  --jsx=automatic \
+  --alias:@do-md/utils=../../utils \
+  --alias:@do-md/zenith=../../zenith \
+  --outfile=scripts/verify-search/out.mjs || exit 1
+node scripts/verify-search/out.mjs

--- a/.packages/@do-md/plugins/search/src/highlight.ts
+++ b/.packages/@do-md/plugins/search/src/highlight.ts
@@ -1,0 +1,250 @@
+/**
+ * Match painting via the CSS Custom Highlight API — the browser's own
+ * find-in-page rendering path: no DOM mutation, no overlay rectangles, no
+ * resize listeners (Ranges are logical positions, not geometry).
+ *
+ * Anchoring: the store's match ranges resolve (kernel `resolveRanges`) to
+ * block coordinates `{ uuid, offset }`, and this module positions them in the
+ * DOM exactly the way remote cursors are drawn — `[data-render-id="${uuid}"]`
+ * plus a text-node walk. The walk skips view-only decoration subtrees
+ * (`data-domd-view-only`, the kernel's public contract), mirroring the
+ * kernel's own cursor-to-DOM math.
+ *
+ * The consuming layer styles the two highlight names in CSS:
+ *
+ *   ::highlight(domd-search)        { background-color: ...; }
+ *   ::highlight(domd-search-active) { background-color: ...; }
+ *
+ * Repaint policy is the caller's (see bindSearchPainter): ranges die when
+ * React replaces the underlying text nodes, so repaint after every op batch
+ * and cursor move (markdown-mode symbol reveal re-renders spans), throttled
+ * to animation frames.
+ */
+import { DATA_VIEW_ONLY } from "@do-md/core-react";
+import type { RangeAnchor, ResolvedMatchRange, SearchStore } from "./store";
+
+export const SEARCH_HIGHLIGHT = "domd-search";
+export const SEARCH_HIGHLIGHT_ACTIVE = "domd-search-active";
+
+/** Chrome 105+, Safari 17.4+, Firefox 140+. On anything older the engine
+ *  still counts/navigates/replaces — it just cannot paint. */
+export const supportsHighlightPainting = (): boolean =>
+    typeof CSS !== "undefined" && "highlights" in CSS;
+
+const DATA_RENDER_ID = "data-render-id";
+
+/** True when the node sits inside a view-only decoration subtree (bounded by
+ *  `block`) — such text occupies DOM but no model offsets. */
+const isViewOnlyText = (node: Node, block: Element): boolean => {
+    let parent = node.parentElement;
+    while (parent && parent !== block) {
+        if (parent.hasAttribute(DATA_VIEW_ONLY)) return true;
+        parent = parent.parentElement;
+    }
+    return false;
+};
+
+/** Resolve (block uuid, in-block offset) to a text-node position — the
+ *  remote-cursor walk, view-only aware. Null when the block is gone or holds
+ *  no text nodes. */
+const resolveTextPoint = (
+    container: HTMLElement,
+    anchor: RangeAnchor,
+): { node: Text; offset: number } | null => {
+    const block = container.querySelector<HTMLElement>(
+        `[${DATA_RENDER_ID}="${CSS.escape(anchor.uuid)}"]`,
+    );
+    if (!block) return null;
+    const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT, {
+        acceptNode: (node) =>
+            isViewOnlyText(node, block)
+                ? NodeFilter.FILTER_REJECT
+                : NodeFilter.FILTER_ACCEPT,
+    });
+    let remaining = anchor.offset;
+    let node = walker.nextNode() as Text | null;
+    let last: Text | null = null;
+    while (node) {
+        const length = node.textContent?.length ?? 0;
+        last = node;
+        if (remaining <= length) {
+            return { node, offset: Math.min(remaining, length) };
+        }
+        remaining -= length;
+        node = walker.nextNode() as Text | null;
+    }
+    if (last) return { node: last, offset: last.length };
+    return null;
+};
+
+const toDomRange = (
+    container: HTMLElement,
+    resolved: ResolvedMatchRange,
+): Range | null => {
+    const start = resolveTextPoint(container, resolved.start);
+    const end = resolveTextPoint(container, resolved.end);
+    if (!start || !end) return null;
+    const range = document.createRange();
+    try {
+        range.setStart(start.node, start.offset);
+        range.setEnd(end.node, end.offset);
+    } catch {
+        return null;
+    }
+    if (range.collapsed) return null;
+    return range;
+};
+
+/** Paint one frame of highlights. `activeIndex` addresses `anchors` (slot
+ *  order = match order); the active range paints under its own name, above
+ *  the rest. */
+export const paintHighlights = (
+    container: HTMLElement,
+    anchors: (ResolvedMatchRange | null)[],
+    activeIndex: number,
+): void => {
+    if (!supportsHighlightPainting()) return;
+    const all: Range[] = [];
+    let active: Range | null = null;
+    anchors.forEach((resolved, index) => {
+        if (!resolved) return;
+        const range = toDomRange(container, resolved);
+        if (!range) return;
+        if (index === activeIndex) active = range;
+        else all.push(range);
+    });
+    const registry = CSS.highlights;
+    const passive = new Highlight(...all);
+    registry.set(SEARCH_HIGHLIGHT, passive);
+    if (active) {
+        const highlight = new Highlight(active);
+        highlight.priority = 1;
+        registry.set(SEARCH_HIGHLIGHT_ACTIVE, highlight);
+    } else {
+        registry.delete(SEARCH_HIGHLIGHT_ACTIVE);
+    }
+};
+
+export const clearHighlights = (): void => {
+    if (!supportsHighlightPainting()) return;
+    CSS.highlights.delete(SEARCH_HIGHLIGHT);
+    CSS.highlights.delete(SEARCH_HIGHLIGHT_ACTIVE);
+};
+
+/** Scroll the active match into view, centered when off-screen. */
+const scrollToRange = (container: HTMLElement, range: Range): void => {
+    const rect = range.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) return;
+    let scroller: HTMLElement | null = container;
+    while (scroller) {
+        const style = getComputedStyle(scroller);
+        if (/(auto|scroll|overlay)/.test(style.overflowY)) break;
+        scroller = scroller.parentElement;
+    }
+    if (!scroller) return;
+    const view = scroller.getBoundingClientRect();
+    if (rect.top >= view.top && rect.bottom <= view.bottom) return;
+    scroller.scrollTop +=
+        rect.top - view.top - view.height / 2 + rect.height / 2;
+};
+
+/** The editor subset the painter observes. `subscribeCursorChange` is
+ *  optional but recommended: caret moves re-render markdown syntax symbols,
+ *  which replaces the very text nodes the ranges hang on. */
+export interface PaintableEditor {
+    subscribeRenderDataOps(listener: (ops: unknown[]) => void): () => void;
+    subscribeCursorChange?(listener: (cursor: unknown) => void): () => void;
+}
+
+/**
+ * Wire a SearchStore to a live editor container: repaints on search state
+ * changes, document ops and cursor moves (rAF-throttled — Ranges do not
+ * survive React re-renders), scrolls to the active match when it changes,
+ * clears on dispose. Returns the dispose.
+ */
+export const bindSearchPainter = (
+    search: SearchStore,
+    editor: PaintableEditor,
+    container: HTMLElement,
+): (() => void) => {
+    if (!supportsHighlightPainting()) return () => {};
+
+    let disposed = false;
+    let framePending = false;
+    let lastActiveIndex = -1;
+    /** Anchors are model-level: they only change when matches change, not
+     *  when React re-renders — cache per matches array identity. */
+    let anchorsFor: unknown = null;
+    let anchors: (ResolvedMatchRange | null)[] = [];
+
+    const paint = () => {
+        if (disposed) return;
+        const { open, matches, activeIndex } = search.state;
+        if (!open || matches.length === 0) {
+            clearHighlights();
+            lastActiveIndex = -1;
+            anchorsFor = null;
+            return;
+        }
+        if (anchorsFor !== matches) {
+            anchors = search.resolveMatchAnchors();
+            anchorsFor = matches;
+        }
+        paintHighlights(container, anchors, activeIndex);
+        if (activeIndex !== lastActiveIndex && activeIndex >= 0) {
+            lastActiveIndex = activeIndex;
+            const resolved =
+                anchors[activeIndex] ??
+                // Beyond the resolution cap the active match rides in the
+                // extra tail slot resolveMatchAnchors appends.
+                anchors[anchors.length - 1];
+            const range = resolved ? toDomRange(container, resolved) : null;
+            if (range) scrollToRange(container, range);
+        }
+    };
+
+    const schedule = () => {
+        if (disposed) return;
+        // Closing must not wait for a frame: rAF is suspended in hidden tabs,
+        // which would leave stale highlights behind a dismissed widget.
+        if (!search.state.open || search.state.matches.length === 0) {
+            clearHighlights();
+            lastActiveIndex = -1;
+            anchorsFor = null;
+            return;
+        }
+        if (framePending) return;
+        framePending = true;
+        requestAnimationFrame(() => {
+            framePending = false;
+            paint();
+        });
+    };
+
+    // The op/cursor subscriptions cover model-driven re-renders, but some
+    // re-renders emit neither — the rich↔markdown mode toggle rebuilds every
+    // span with zero model change, killing the very text nodes the Ranges
+    // hang on. A MutationObserver on the container is the catch-all: any DOM
+    // rebuild schedules a repaint. Safe against feedback loops — painting
+    // goes through CSS.highlights, which never mutates the DOM.
+    const observer = new MutationObserver(schedule);
+    observer.observe(container, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+    });
+
+    const unsubscribers = [
+        search.subscribe(schedule),
+        editor.subscribeRenderDataOps(schedule),
+        editor.subscribeCursorChange?.(schedule),
+    ];
+    schedule();
+
+    return () => {
+        disposed = true;
+        observer.disconnect();
+        for (const unsubscribe of unsubscribers) unsubscribe?.();
+        clearHighlights();
+    };
+};

--- a/.packages/@do-md/plugins/search/src/index.ts
+++ b/.packages/@do-md/plugins/search/src/index.ts
@@ -1,0 +1,52 @@
+/**
+ * @do-md/search — headless find & replace for the @do-md/core-react editor.
+ *
+ * Three layers, composable and framework-free:
+ *   - matcher: pure VSCode-semantics text matching (case / whole word / regex,
+ *     replacement expansion, preserve-case) over the markdown source.
+ *   - SearchStore: a zenith store orchestrating scan / navigate / replace
+ *     through the kernel's public replace family (replaceRanges,
+ *     setSelection, getSelectionOffsets, resolveRanges).
+ *   - highlight: CSS Custom Highlight painting of every match, anchored the
+ *     way remote cursors are drawn.
+ *
+ * The UI on top is the consumer's: render SearchStore state, call its
+ * actions, bind the painter to the editor container.
+ */
+export {
+    compileQuery,
+    findMatches,
+    expandReplacement,
+    preserveCase,
+    DEFAULT_MATCH_LIMIT,
+} from "./matcher";
+export type {
+    SearchOptions,
+    SearchMatch,
+    CompiledQuery,
+    FindMatchesResult,
+} from "./matcher";
+
+export { SearchStore } from "./store";
+export type {
+    SearchState,
+    SearchableEditor,
+    RangeAnchor,
+    ResolvedMatchRange,
+} from "./store";
+
+export {
+    SearchStoreProvider,
+    useSearchStore,
+    useSearchStoreApi,
+} from "./react";
+
+export {
+    bindSearchPainter,
+    paintHighlights,
+    clearHighlights,
+    supportsHighlightPainting,
+    SEARCH_HIGHLIGHT,
+    SEARCH_HIGHLIGHT_ACTIVE,
+} from "./highlight";
+export type { PaintableEditor } from "./highlight";

--- a/.packages/@do-md/plugins/search/src/matcher.ts
+++ b/.packages/@do-md/plugins/search/src/matcher.ts
@@ -1,0 +1,220 @@
+/**
+ * Pure text matching with VSCode find-widget semantics. No editor, no DOM —
+ * every function here maps strings to ranges, so the whole search engine is
+ * unit-testable headless and reusable by any kernel consumer.
+ *
+ * Coordinate space: absolute character offsets into whatever text the caller
+ * scanned — for DoMD that is the kernel's `toMarkdown()` serialization, which
+ * makes every match range directly consumable by `setSelection` /
+ * `replaceRanges` / `resolveRanges` (the replace family shares this space).
+ */
+
+export interface SearchOptions {
+    /** Aa — exact case matching. Off: case-insensitive (regex flag `i`). */
+    caseSensitive: boolean;
+    /** ab| — both match edges must sit on a word boundary (VSCode's
+     *  separator-based definition, not `\b`). */
+    wholeWord: boolean;
+    /** .* — treat the query as an ECMAScript regular expression. */
+    regex: boolean;
+}
+
+export interface SearchMatch {
+    /** Absolute offset, inclusive. */
+    start: number;
+    /** Absolute offset, exclusive. */
+    end: number;
+    /**
+     * Capture groups of a regex match (`[0]` = whole match) — captured at
+     * scan time so replacement expansion sees exactly the groups the scan
+     * saw, regardless of later document edits.
+     */
+    groups?: string[];
+}
+
+export type CompiledQuery =
+    /** Empty query — matches nothing, distinct from an error. */
+    | { kind: "empty" }
+    /** Malformed regex — `message` is the engine's parse error. */
+    | { kind: "error"; message: string }
+    | { kind: "ok"; pattern: RegExp };
+
+const REGEX_SPECIALS = /[.*+?^${}()|[\]\\]/g;
+
+/**
+ * Compile a query + options into a global regex, VSCode-style: literal
+ * queries are escaped; `m` is always on (`^`/`$` address lines, matching the
+ * find widget); the `u` flag is attempted first and dropped when the pattern
+ * only parses without it (many hand-written patterns use escapes that are
+ * errors under `u`).
+ */
+export const compileQuery = (
+    query: string,
+    options: SearchOptions,
+): CompiledQuery => {
+    if (!query) return { kind: "empty" };
+    const source = options.regex
+        ? query
+        : query.replace(REGEX_SPECIALS, "\\$&");
+    const flags = `gm${options.caseSensitive ? "" : "i"}`;
+    try {
+        return { kind: "ok", pattern: new RegExp(source, `${flags}u`) };
+    } catch {
+        try {
+            return { kind: "ok", pattern: new RegExp(source, flags) };
+        } catch (error) {
+            return {
+                kind: "error",
+                message:
+                    error instanceof Error ? error.message : String(error),
+            };
+        }
+    }
+};
+
+/**
+ * VSCode's default word separators. A boundary is valid when the adjacent
+ * character is missing (text edge), whitespace, or one of these — or when the
+ * match's own edge character is itself a separator (so searching `(foo)`
+ * whole-word still matches). CJK behaves as in VSCode: ideographs count as
+ * word characters.
+ */
+const WORD_SEPARATORS = new Set("`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?");
+
+const isBoundaryChar = (char: string | undefined): boolean =>
+    char === undefined || /\s/.test(char) || WORD_SEPARATORS.has(char);
+
+const isWholeWordMatch = (text: string, start: number, end: number): boolean =>
+    (isBoundaryChar(text[start - 1]) || isBoundaryChar(text[start])) &&
+    (isBoundaryChar(text[end]) || isBoundaryChar(text[end - 1]));
+
+export interface FindMatchesResult {
+    matches: SearchMatch[];
+    /** True when the scan stopped at `limit` — the tail of the document was
+     *  not searched. Surface this; a silently truncated count reads as
+     *  exhaustive. */
+    limitHit: boolean;
+}
+
+/** VSCode caps its find at 20k matches; same order of magnitude here. */
+export const DEFAULT_MATCH_LIMIT = 20000;
+
+/**
+ * All non-overlapping matches, left to right. Zero-length regex matches are
+ * skipped (an empty "match everywhere" is noise in a find widget), advancing
+ * one character so the scan always terminates.
+ */
+export const findMatches = (
+    text: string,
+    compiled: CompiledQuery,
+    options: SearchOptions,
+    limit: number = DEFAULT_MATCH_LIMIT,
+): FindMatchesResult => {
+    if (compiled.kind !== "ok") return { matches: [], limitHit: false };
+    const pattern = compiled.pattern;
+    pattern.lastIndex = 0;
+    const matches: SearchMatch[] = [];
+    for (;;) {
+        const found = pattern.exec(text);
+        if (!found) break;
+        const start = found.index;
+        const end = start + found[0].length;
+        if (found[0].length === 0) {
+            pattern.lastIndex += 1;
+            continue;
+        }
+        if (!options.wholeWord || isWholeWordMatch(text, start, end)) {
+            const match: SearchMatch = { start, end };
+            if (options.regex && found.length > 1) {
+                match.groups = Array.from(found, (g) => g ?? "");
+            } else if (options.regex) {
+                match.groups = [found[0]];
+            }
+            matches.push(match);
+            if (matches.length >= limit) {
+                return { matches, limitHit: pattern.exec(text) !== null };
+            }
+        }
+    }
+    return { matches, limitHit: false };
+};
+
+/**
+ * Expand a replacement template against one match, regex-mode: `$$` → `$`,
+ * `$&` / `$0` → whole match, `$1`…`$99` → capture group (empty when the group
+ * did not participate), `\n` / `\t` / `\\` → escapes (VSCode supports these
+ * in regex replace). Everything else is literal. Non-regex callers should
+ * pass the template through untouched instead of calling this.
+ */
+export const expandReplacement = (
+    template: string,
+    match: SearchMatch,
+): string => {
+    const groups = match.groups ?? [];
+    let out = "";
+    let i = 0;
+    while (i < template.length) {
+        const char = template[i];
+        if (char === "\\" && i + 1 < template.length) {
+            const next = template[i + 1];
+            if (next === "n") out += "\n";
+            else if (next === "t") out += "\t";
+            else if (next === "\\") out += "\\";
+            else out += char + next;
+            i += 2;
+            continue;
+        }
+        if (char === "$" && i + 1 < template.length) {
+            const next = template[i + 1];
+            if (next === "$") {
+                out += "$";
+                i += 2;
+                continue;
+            }
+            if (next === "&") {
+                out += groups[0] ?? "";
+                i += 2;
+                continue;
+            }
+            if (next >= "0" && next <= "9") {
+                let num = next;
+                if (
+                    i + 2 < template.length &&
+                    template[i + 2] >= "0" &&
+                    template[i + 2] <= "9" &&
+                    Number(num + template[i + 2]) < groups.length
+                ) {
+                    num += template[i + 2];
+                }
+                const groupIndex = Number(num);
+                if (groupIndex < groups.length) {
+                    out += groups[groupIndex] ?? "";
+                    i += 1 + num.length;
+                    continue;
+                }
+            }
+        }
+        out += char;
+        i += 1;
+    }
+    return out;
+};
+
+/**
+ * AB — carry the matched text's casing onto the replacement (VSCode's
+ * preserve-case): ALL-UPPER match → upper replacement; all-lower → lower;
+ * Title-case (first letter upper) → first letter upper, rest as typed.
+ * Matches without cased letters pass the replacement through.
+ */
+export const preserveCase = (matched: string, replacement: string): string => {
+    if (!matched || !replacement) return replacement;
+    const hasCased = /[a-zA-Z]/.test(matched);
+    if (!hasCased) return replacement;
+    if (matched === matched.toUpperCase()) return replacement.toUpperCase();
+    if (matched === matched.toLowerCase()) return replacement.toLowerCase();
+    const first = matched[0];
+    if (first === first.toUpperCase() && first !== first.toLowerCase()) {
+        return replacement[0].toUpperCase() + replacement.slice(1);
+    }
+    return replacement;
+};

--- a/.packages/@do-md/plugins/search/src/react.ts
+++ b/.packages/@do-md/plugins/search/src/react.ts
@@ -1,0 +1,25 @@
+/**
+ * React bindings — the kernel's own posture (`createReactStore(EditorStore)`
+ * → EditorStoreProvider / useEditorStoreApi / useEditorStore), applied to
+ * SearchStore:
+ *
+ *   <SearchStoreProvider>          one store instance per provider mount
+ *       ...anything that needs the widget or its actions...
+ *   </SearchStoreProvider>
+ *
+ * `useSearchStoreApi()` hands any descendant the instance (a menu item calls
+ * `.openFind()` directly — no event bridging), `useSearchStore(s => ...)` is
+ * the selector hook (the selector receives the STORE; read `s.state.x`).
+ *
+ * React enters the dependency graph through zenith (already a react>=18
+ * peer), so this module adds no dependency edge — non-React consumers simply
+ * never import these names.
+ */
+import { createReactStore } from "@do-md/zenith";
+import { SearchStore } from "./store";
+
+export const {
+    StoreProvider: SearchStoreProvider,
+    useStoreApi: useSearchStoreApi,
+    useStore: useSearchStore,
+} = createReactStore(SearchStore);

--- a/.packages/@do-md/plugins/search/src/store.ts
+++ b/.packages/@do-md/plugins/search/src/store.ts
@@ -1,0 +1,391 @@
+/**
+ * Headless find & replace state machine — a zenith store over the kernel's
+ * public editing surface. No React, no DOM: the UI layer renders this state
+ * and calls these actions; painting lives in ./highlight.
+ *
+ * Design decisions (VSCode find-widget parity, adapted to a WYSIWYG host):
+ *
+ * - SEARCH SPACE IS THE MARKDOWN SOURCE — the same `toMarkdown()` space the
+ *   kernel's replace family addresses, so every match range feeds
+ *   `replaceRanges` / `resolveRanges` verbatim. A phrase spanning a formatting
+ *   marker (`hello **world**`) does not match "hello world", exactly like
+ *   source-space find in Obsidian's live preview.
+ *
+ * - NAVIGATION NEVER MOVES THE REAL SELECTION. The current match is painted
+ *   as a decoration (CSS Custom Highlight), not selected — moving the model
+ *   selection while the find input holds focus would fight the input for the
+ *   document selection and broadcast presence noise to collaborators. The
+ *   model selection is placed once, on close(), so dismissing the widget
+ *   leaves the caret at the current match (VSCode's Escape behavior).
+ *
+ * - REPLACE ALL IS ONE `replaceRanges` CALL — the kernel folds the batch into
+ *   a single undo step and fine-grained collab ops; per-match regex group
+ *   expansion and preserve-case are computed here, from groups captured at
+ *   scan time.
+ */
+import { ZenithStore } from "@do-md/zenith";
+import {
+    CompiledQuery,
+    DEFAULT_MATCH_LIMIT,
+    SearchMatch,
+    SearchOptions,
+    compileQuery,
+    expandReplacement,
+    findMatches,
+    preserveCase,
+} from "./matcher";
+
+/** One resolved endpoint: block uuid + in-block text offset (the kernel's
+ *  CursorSnapshot vocabulary). Typed structurally so this package compiles
+ *  against kernels that predate resolveRanges. */
+export interface RangeAnchor {
+    uuid: string;
+    offset: number;
+}
+
+export interface ResolvedMatchRange {
+    start: RangeAnchor;
+    end: RangeAnchor;
+}
+
+/**
+ * The slice of the kernel's EditorStore this engine consumes — structural,
+ * so any store satisfying it works and older kernels degrade gracefully:
+ * `resolveRanges` (kernel >=0.11.7) is optional and only gates highlight
+ * painting, never search/replace itself.
+ */
+export interface SearchableEditor {
+    toMarkdown(): string;
+    setSelection(target: { start: number; end?: number }): {
+        applied: boolean;
+    };
+    replaceRanges(
+        ...edits: { start: number; end: number; text: string }[]
+    ): unknown;
+    getSelectionOffsets(): { start: number; end: number } | null;
+    subscribeRenderDataOps(listener: (ops: unknown[]) => void): () => void;
+    /** Optional: feeds the open-with-selection prefill (VSCode's ⌘F). */
+    getSelectionState?(): { selected_text: string };
+    resolveRanges?(
+        ...ranges: { start: number; end: number }[]
+    ): (ResolvedMatchRange | null)[];
+}
+
+export interface SearchState {
+    /** Widget visibility. Closed = no scanning, no highlights. */
+    open: boolean;
+    /** Replace row expanded (the chevron / ⌥⌘F state). */
+    replaceExpanded: boolean;
+    query: string;
+    replacement: string;
+    caseSensitive: boolean;
+    wholeWord: boolean;
+    regex: boolean;
+    preserveCase: boolean;
+    matches: SearchMatch[];
+    /** Index into `matches`; -1 when there is no match. */
+    activeIndex: number;
+    /** Regex parse error (regex mode only) — render the input invalid. */
+    queryError: string | null;
+    /** The scan stopped at the match limit; the count is a floor, not exact. */
+    limitHit: boolean;
+}
+
+const INITIAL_STATE: SearchState = {
+    open: false,
+    replaceExpanded: false,
+    query: "",
+    replacement: "",
+    caseSensitive: false,
+    wholeWord: false,
+    regex: false,
+    preserveCase: false,
+    matches: [],
+    activeIndex: -1,
+    queryError: null,
+    limitHit: false,
+};
+
+export class SearchStore extends ZenithStore<SearchState> {
+    private editor_: SearchableEditor | null = null;
+    private unsubscribeOps_: (() => void) | null = null;
+
+    constructor() {
+        super(INITIAL_STATE);
+    }
+
+    /** Wire the engine to an editor store. Idempotent per editor; call the
+     *  returned dispose (or detach()) when the editor unmounts. */
+    public attach(editor: SearchableEditor): () => void {
+        if (this.editor_ === editor) return () => this.detach();
+        this.detach();
+        this.editor_ = editor;
+        // Document edits (local typing, collab ops, AI edits) invalidate the
+        // scanned offsets — rescan while the widget is open. The active match
+        // is re-anchored to the nearest offset, so the widget does not jump
+        // to the first match on every keystroke.
+        this.unsubscribeOps_ = editor.subscribeRenderDataOps(() => {
+            if (this.state.open) this.rescan_({ keepNear: true });
+        });
+        return () => this.detach();
+    }
+
+    public detach() {
+        this.unsubscribeOps_?.();
+        this.unsubscribeOps_ = null;
+        this.editor_ = null;
+        this.produce((draft) => {
+            Object.assign(draft, INITIAL_STATE);
+        });
+    }
+
+    /** Resolve current matches to block anchors for highlight painting.
+     *  Empty on kernels without resolveRanges (paint nothing, everything
+     *  else still works). `limit` caps the resolution cost on huge match
+     *  sets — the painter cannot show 20k highlights usefully anyway. */
+    public resolveMatchAnchors(
+        limit: number = 1000,
+    ): (ResolvedMatchRange | null)[] {
+        const editor = this.editor_;
+        if (!editor?.resolveRanges) return [];
+        const { matches, activeIndex } = this.state;
+        if (matches.length === 0) return [];
+        const capped = matches.slice(0, limit);
+        // The active match must always be resolvable, even beyond the cap.
+        if (activeIndex >= limit) capped.push(matches[activeIndex]);
+        return editor.resolveRanges(
+            ...capped.map(({ start, end }) => ({ start, end })),
+        );
+    }
+
+    // ================================================================
+    // Widget lifecycle
+    // ================================================================
+
+    /**
+     * The editor's current selection when it makes a sensible query seed —
+     * single line, non-empty, sane length (VSCode's prefill rule). Undefined
+     * otherwise, so the previous query survives reopening.
+     */
+    private selectionPrefill_(): string | undefined {
+        const text = this.editor_?.getSelectionState?.().selected_text;
+        if (!text || text.includes("\n") || text.length > 1000) {
+            return undefined;
+        }
+        return text;
+    }
+
+    /**
+     * Open the widget (⌘F, or the top-bar menu entry — same call, same
+     * semantics). A single-line editor selection prefills the query,
+     * VSCode-style; otherwise the previous query is kept and re-scanned. The
+     * active match starts at the first match at or after the caret.
+     */
+    public openFind() {
+        const prefill = this.selectionPrefill_();
+        this.produce((draft) => {
+            draft.open = true;
+            if (prefill) {
+                draft.query = prefill;
+                draft.queryError = null;
+            }
+        });
+        this.rescan_({ fromCursor: true });
+    }
+
+    /** Open with the replace row expanded (⌥⌘F / Ctrl+H). */
+    public openReplace() {
+        this.produce((draft) => {
+            draft.replaceExpanded = true;
+        });
+        this.openFind();
+    }
+
+    public toggleReplaceExpanded() {
+        this.produce((draft) => {
+            draft.replaceExpanded = !draft.replaceExpanded;
+        });
+    }
+
+    /**
+     * Close the widget and land the model selection on the current match, so
+     * the caret ends up where the user was looking (VSCode's Escape). The
+     * app layer refocuses the editor.
+     */
+    public close() {
+        const { matches, activeIndex } = this.state;
+        const active = activeIndex >= 0 ? matches[activeIndex] : undefined;
+        this.produce((draft) => {
+            draft.open = false;
+            draft.replaceExpanded = false;
+            draft.matches = [];
+            draft.activeIndex = -1;
+            draft.limitHit = false;
+        });
+        if (active && this.editor_) {
+            this.editor_.setSelection({ start: active.start, end: active.end });
+        }
+    }
+
+    // ================================================================
+    // Query / options
+    // ================================================================
+
+    public setQuery(query: string) {
+        this.produce((draft) => {
+            draft.query = query;
+        });
+        this.rescan_({ fromCursor: true });
+    }
+
+    public setReplacement(replacement: string) {
+        this.produce((draft) => {
+            draft.replacement = replacement;
+        });
+    }
+
+    public setOption(option: keyof SearchOptions | "preserveCase", value: boolean) {
+        this.produce((draft) => {
+            draft[option] = value;
+        });
+        if (option !== "preserveCase") this.rescan_({ keepNear: true });
+    }
+
+    // ================================================================
+    // Navigation — decoration-only, see the header note
+    // ================================================================
+
+    public findNext() {
+        this.step_(1);
+    }
+
+    public findPrevious() {
+        this.step_(-1);
+    }
+
+    private step_(direction: 1 | -1) {
+        const { matches, activeIndex } = this.state;
+        if (matches.length === 0) return;
+        const next =
+            activeIndex < 0
+                ? direction === 1
+                    ? 0
+                    : matches.length - 1
+                : (activeIndex + direction + matches.length) % matches.length;
+        this.produce((draft) => {
+            draft.activeIndex = next;
+        });
+    }
+
+    // ================================================================
+    // Replace
+    // ================================================================
+
+    /** Replacement text for one match, honoring regex groups + preserve-case. */
+    private replacementFor_(match: SearchMatch, docText: string): string {
+        const { regex, replacement } = this.state;
+        let text = regex ? expandReplacement(replacement, match) : replacement;
+        if (this.state.preserveCase) {
+            text = preserveCase(docText.slice(match.start, match.end), text);
+        }
+        return text;
+    }
+
+    /**
+     * Replace the current match and advance to the next one (VSCode's
+     * replace button). One kernel call, one undo step; the ops subscription
+     * rescans, then the active match re-anchors to the replacement's end.
+     */
+    public replaceCurrent() {
+        const editor = this.editor_;
+        const { matches, activeIndex } = this.state;
+        if (!editor || activeIndex < 0) return;
+        const match = matches[activeIndex];
+        if (!match) return;
+        const docText = editor.toMarkdown();
+        const text = this.replacementFor_(match, docText);
+        editor.replaceRanges({ start: match.start, end: match.end, text });
+        // The ops subscription has already rescanned synchronously. Advance
+        // past the inserted text (VSCode semantics), so a replacement that
+        // matches the query itself ("a" -> "aa") does not trap the cursor.
+        this.activateAtOrAfter_(match.start + text.length);
+    }
+
+    /** Replace every match in ONE replaceRanges call — a single undo step. */
+    public replaceAll() {
+        const editor = this.editor_;
+        const { matches } = this.state;
+        if (!editor || matches.length === 0) return;
+        const docText = editor.toMarkdown();
+        editor.replaceRanges(
+            ...matches.map((match) => ({
+                start: match.start,
+                end: match.end,
+                text: this.replacementFor_(match, docText),
+            })),
+        );
+    }
+
+    // ================================================================
+    // Scanning
+    // ================================================================
+
+    private compile_(): CompiledQuery {
+        const { query, caseSensitive, wholeWord, regex } = this.state;
+        return compileQuery(query, { caseSensitive, wholeWord, regex });
+    }
+
+    /**
+     * Recompute matches against the current document.
+     * `fromCursor`: activate the first match at/after the caret (open, query
+     * edits). `keepNear`: re-anchor to the previous active offset (document
+     * edits, option toggles).
+     */
+    private rescan_(anchor: { fromCursor?: boolean; keepNear?: boolean }) {
+        const editor = this.editor_;
+        if (!editor || !this.state.open) return;
+        const previousActive =
+            this.state.activeIndex >= 0
+                ? this.state.matches[this.state.activeIndex]?.start
+                : undefined;
+        const compiled = this.compile_();
+        const { caseSensitive, wholeWord, regex } = this.state;
+        const scan =
+            compiled.kind === "ok"
+                ? findMatches(
+                      editor.toMarkdown(),
+                      compiled,
+                      { caseSensitive, wholeWord, regex },
+                      DEFAULT_MATCH_LIMIT,
+                  )
+                : { matches: [], limitHit: false };
+        this.produce((draft) => {
+            draft.matches = scan.matches;
+            draft.limitHit = scan.limitHit;
+            draft.queryError =
+                compiled.kind === "error" ? compiled.message : null;
+            draft.activeIndex = -1;
+        });
+        if (scan.matches.length === 0) return;
+        if (anchor.keepNear && previousActive !== undefined) {
+            this.activateAtOrAfter_(previousActive);
+        } else if (anchor.fromCursor) {
+            const offsets = editor.getSelectionOffsets();
+            this.activateAtOrAfter_(offsets ? offsets.start : 0);
+        } else {
+            this.activateAtOrAfter_(0);
+        }
+    }
+
+    /** Activate the first match starting at/after `offset`, wrapping to the
+     *  first match when none follows. */
+    private activateAtOrAfter_(offset: number) {
+        const { matches } = this.state;
+        if (matches.length === 0) return;
+        let index = matches.findIndex((match) => match.start >= offset);
+        if (index === -1) index = 0;
+        this.produce((draft) => {
+            draft.activeIndex = index;
+        });
+    }
+}

--- a/.packages/@do-md/plugins/search/tsconfig.json
+++ b/.packages/@do-md/plugins/search/tsconfig.json
@@ -1,0 +1,42 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "useDefineForClassFields": true,
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "skipLibCheck": true,
+
+        /* Bundler mode — deliberately NOT NodeNext.
+           The DoMD app consumes this package's source through tsconfig paths, and
+           Turbopack resolves relative specifiers literally: a NodeNext-style
+           "./target.js" import never finds target.ts (Next's extensionAlias escape
+           hatch is webpack-only). Source therefore imports extensionless, and the
+           published artifact is a single bundled file with no relative specifiers
+           left to resolve — see vite.config.ts. */
+        "moduleResolution": "bundler",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+
+        /* Linting */
+        "strict": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noFallthroughCasesInSwitch": true,
+
+        /* Declaration */
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "esModuleInterop": true,
+        "outDir": "./dist",
+        "rootDir": "./src",
+
+        /* No paths override: @do-md/core-react resolves to the PUBLISHED
+           package in node_modules (devDependency), so every command
+           typechecks against the kernel's public declarations exactly as a
+           third-party consumer sees them. If a command ever reaches for an
+           internal (`_`-suffixed) member, or for a method that was never
+           promised, the build breaks here rather than at some consumer's. */
+    },
+    "include": ["src"]
+}

--- a/.packages/@do-md/plugins/search/vite.config.ts
+++ b/.packages/@do-md/plugins/search/vite.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "vite";
+import { resolve } from "path";
+
+// Same bundling rationale as ../commands/vite.config.ts: the DoMD app consumes this
+// package's *source* (tsconfig paths -> src/index.ts), so src/ imports extensionless
+// (Turbopack resolves relative specifiers literally), and the published artifact is a
+// single dist/index.js with no relative specifiers left inside it.
+//
+// Externals: the kernel (value import — DATA_VIEW_ONLY — must resolve to the consumer's
+// kernel instance, never a second inlined copy) and zenith (the store base class must be
+// the same module instance the consuming app subscribes through).
+export default defineConfig({
+    build: {
+        lib: {
+            entry: resolve(__dirname, "src/index.ts"),
+            fileName: "index",
+            formats: ["es"],
+        },
+        // Unminified on purpose: this is a library. The consuming app minifies, and a
+        // readable dist keeps stack traces from released plugins worth reading.
+        minify: false,
+        sourcemap: true,
+        target: "es2020",
+        rollupOptions: {
+            external: ["@do-md/core-react", "@do-md/zenith"],
+        },
+    },
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -384,3 +384,13 @@ body {
         break-after: avoid;
     }
 }
+
+/* Find & replace match painting (@do-md/search, CSS Custom Highlight API).
+ * Muted amber for the field, a stronger tone for the current match — kept
+ * translucent so they read on both light surfaces and code blocks. */
+::highlight(domd-search) {
+    background-color: rgb(203 161 53 / 0.28);
+}
+::highlight(domd-search-active) {
+    background-color: rgb(199 116 48 / 0.5);
+}

--- a/common/i18n/locales/en.json
+++ b/common/i18n/locales/en.json
@@ -111,6 +111,23 @@
             "modeTitle": "Rich mode & Markdown mode",
             "modeBody": "You are in rich mode: Markdown turns into clean formatted text as you type. Markdown mode is WYSIWYG too — formatting still renders live, but the Markdown marks stay visible for precise control. Toggle any time via the **⋯** menu or **{{shortcut}}** — your choice is remembered.",
             "outro": "Happy writing!"
+        },
+        "find": {
+            "menuTitle": "Find & replace",
+            "placeholder": "Find",
+            "replacePlaceholder": "Replace",
+            "count": "{{current}} of {{total}}",
+            "noResults": "No results",
+            "caseSensitive": "Match case",
+            "wholeWord": "Match whole word",
+            "regex": "Use regular expression",
+            "preserveCase": "Preserve case",
+            "previous": "Previous match (⇧Enter)",
+            "next": "Next match (Enter)",
+            "close": "Close (Esc)",
+            "replaceOne": "Replace",
+            "replaceAll": "Replace all",
+            "toggleReplace": "Toggle replace"
         }
     },
     "updater": {

--- a/common/i18n/locales/ja.json
+++ b/common/i18n/locales/ja.json
@@ -111,6 +111,23 @@
             "modeTitle": "リッチモードと Markdown モード",
             "modeBody": "現在はリッチモードで、入力した Markdown は即座に整形されたテキストになります。Markdown モードも同じく WYSIWYG——書式はリアルタイムで反映されたまま、Markdown 記号も表示されるため細かな調整がしやすくなります。**⋯** メニューまたは **{{shortcut}}** でいつでも切り替えられ、選択は記憶されます。",
             "outro": "よい執筆を！"
+        },
+        "find": {
+            "menuTitle": "検索と置換",
+            "placeholder": "検索",
+            "replacePlaceholder": "置換",
+            "count": "{{total}} 件中 {{current}} 件目",
+            "noResults": "結果なし",
+            "caseSensitive": "大文字と小文字を区別する",
+            "wholeWord": "単語単位で検索する",
+            "regex": "正規表現を使用する",
+            "preserveCase": "大文字小文字を保持する",
+            "previous": "前の一致項目 (⇧Enter)",
+            "next": "次の一致項目 (Enter)",
+            "close": "閉じる (Esc)",
+            "replaceOne": "置換",
+            "replaceAll": "すべて置換",
+            "toggleReplace": "置換の切り替え"
         }
     },
     "updater": {

--- a/common/i18n/locales/zh.json
+++ b/common/i18n/locales/zh.json
@@ -111,6 +111,23 @@
             "modeTitle": "富文本模式与 Markdown 模式",
             "modeBody": "当前是富文本模式：输入的 Markdown 会即时变成排版好的正文。Markdown 模式同样所见即所得——格式照常实时渲染，但会保留 Markdown 标记符号，便于精确控制。随时可通过 **⋯** 菜单或 **{{shortcut}}** 切换，你的选择会被记住。",
             "outro": "祝写作愉快！"
+        },
+        "find": {
+            "menuTitle": "查找与替换",
+            "placeholder": "查找",
+            "replacePlaceholder": "替换",
+            "count": "第 {{current}} 项，共 {{total}} 项",
+            "noResults": "无结果",
+            "caseSensitive": "区分大小写",
+            "wholeWord": "全字匹配",
+            "regex": "使用正则表达式",
+            "preserveCase": "保留大小写",
+            "previous": "上一个匹配项 (⇧Enter)",
+            "next": "下一个匹配项 (Enter)",
+            "close": "关闭 (Esc)",
+            "replaceOne": "替换",
+            "replaceAll": "全部替换",
+            "toggleReplace": "切换替换"
         }
     },
     "updater": {

--- a/features/editor/components/editor.tsx
+++ b/features/editor/components/editor.tsx
@@ -29,6 +29,11 @@ import {
     TocController,
     TOC_TOGGLE_SHORTCUT,
 } from "@/features/editor/components/toc-panel";
+import {
+    FindBar,
+    FindMenuItem,
+} from "@/features/editor/components/find-bar";
+import { SearchStoreProvider } from "@do-md/search";
 import { getGrammarVersion, subscribeGrammarLoad } from "@/common/lib/prism";
 import { useApplePlatform } from "@/common/hooks/use-apple-platform";
 import { isTauri } from "@/common/lib/platform";
@@ -517,12 +522,13 @@ export function Editor({
         // rules in globals.css unlock this fixed/overflow layout into a
         // plain document flow so native printing (desktop Export PDF, web
         // Cmd+P) paginates the whole document instead of one viewport.
-        // TocStoreProvider scopes one outline store to this editor: the
-        // trigger button (top bar), TocController (engine + scroll-spy
-        // wiring) and TocPanel (the side-panel occupant, resolved by
-        // editor-app) share it. Context only, no DOM wrapper — same posture
-        // as DOMDProvider.
+        // TocStoreProvider scopes one outline store to this editor (trigger
+        // button, TocController, TocPanel); SearchStoreProvider scopes one
+        // find/replace store (FindBar in the scroll container, FindMenuItem
+        // in the ⋯ menu — the menu entry IS the keyboard shortcut). Both are
+        // context only, no DOM wrapper — same posture as DOMDProvider.
         <TocStoreProvider>
+        <SearchStoreProvider>
         <div className="domd-editor-shell fixed inset-0 bg-base-100 overflow-hidden">
             {/* Format shortcuts (⌘1/⌘K/⌥⌘C/…) live outside the top bar: the
                 desktop build renders no web top bar, and they must work
@@ -706,6 +712,12 @@ export function Editor({
                                         />
                                     </label>
                                 </li>
+                                {/* Find & replace: the only entry point on
+                                    touch devices (no ⌘F). Shares the
+                                    SearchStore with FindBar through the
+                                    provider — literally the same openFind()
+                                    call the keyboard shortcut makes. */}
+                                {isEditable ? <FindMenuItem /> : null}
                                 <li>
                                     <button
                                         onClick={(e) => {
@@ -763,6 +775,12 @@ export function Editor({
                             store?.focus();
                         }}
                     >
+                        {/* Find & replace widget: a zero-height sticky layer
+                            inside the scroll container, so it pins to the top
+                            of the document column and tracks its width when
+                            the side panel squeezes it. Works on desktop too —
+                            no dependency on the web top bar. */}
+                        {isEditable ? <FindBar /> : null}
                         <div className="max-w-3xl mx-auto px-6 py-8">
                             <div ref={domdRef}>
                                 <DOMD />
@@ -775,6 +793,7 @@ export function Editor({
                 <QuickInputBar pin={keyboardPin} />
             </div>
         </div>
+        </SearchStoreProvider>
         </TocStoreProvider>
     );
 }

--- a/features/editor/components/find-bar.tsx
+++ b/features/editor/components/find-bar.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+/**
+ * VSCode-style find & replace widget — the thin UI over @do-md/search. All
+ * engine logic (matching, navigation, replace, highlight painting) lives in
+ * the package; this component renders SearchStore state and forwards actions.
+ *
+ * Must sit inside a DOMDProvider AND a SearchStoreProvider (the store is
+ * shared with FindMenuItem — the ⋯ menu entry, the only trigger on touch
+ * devices), and inside the editor's scroll container: the widget is a
+ * zero-height sticky layer, so it pins to the visible top of the document
+ * column and respects the column's width when the side panel squeezes it.
+ * Clicks are stopped from bubbling — the scroll container interprets stray
+ * clicks as "focus the editor", which would steal the find input's focus.
+ *
+ * Shortcut discipline (refe-81d227): the primary modifier is platform-split,
+ * never metaKey||ctrlKey. `e.code` is used for letters because macOS ⌥
+ * rewrites `e.key` ("ƒ" for ⌥F). ⌘F intentionally shadows the browser's
+ * native find — an in-document widget replaces it wholesale (the Notion /
+ * Google Docs / Obsidian convention).
+ *
+ *   ⌘F / Ctrl+F        open find (prefilled from the selection)
+ *   ⌥⌘F / Ctrl+H       open with the replace row expanded
+ *   ⌘G / F3 (+⇧)       next / previous match
+ *   Enter / ⇧Enter     next / previous (find input)
+ *   Enter / ⌘Enter     replace one / replace all (replace input)
+ *   Esc                close, land the caret on the current match
+ */
+
+import { useEditorDom, useEditorStoreApi } from "@do-md/core-react";
+import {
+    bindSearchPainter,
+    useSearchStore,
+    useSearchStoreApi,
+} from "@do-md/search";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useApplePlatform } from "@/common/hooks/use-apple-platform";
+
+const ChevronIcon = ({ open }: { open: boolean }) => (
+    <svg
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={`size-3 transition-transform ${open ? "rotate-90" : ""}`}
+    >
+        <path d="M6 4l4 4-4 4" />
+    </svg>
+);
+
+const ArrowIcon = ({ down }: { down?: boolean }) => (
+    <svg
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={`size-3.5 ${down ? "" : "rotate-180"}`}
+    >
+        <path d="M8 3v10M4 9l4 4 4-4" />
+    </svg>
+);
+
+const CloseIcon = () => (
+    <svg
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        className="size-3.5"
+    >
+        <path d="M4 4l8 8M12 4l-8 8" />
+    </svg>
+);
+
+/** Codicon-style "replace": ab → glyph with a swap arrow. */
+const ReplaceOneIcon = () => (
+    <svg
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        className="size-3.5"
+    >
+        <path d="M3.5 5.5v-2h9v2M8 3.5v6" />
+        <path d="M5 12.5h6M9.2 10.7l1.8 1.8-1.8 1.8" />
+    </svg>
+);
+
+const ReplaceAllIcon = () => (
+    <svg
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        className="size-3.5"
+    >
+        <path d="M2.5 4.5v-2h7v2M6 2.5v5" />
+        <path d="M2.5 10.5h5M5.7 8.9l1.6 1.6-1.6 1.6" />
+        <path d="M11.5 5.5h2v8h-8v-2" />
+    </svg>
+);
+
+function ToggleButton({
+    on,
+    title,
+    onClick,
+    children,
+}: {
+    on: boolean;
+    title: string;
+    onClick: () => void;
+    children: React.ReactNode;
+}) {
+    return (
+        <button
+            type="button"
+            title={title}
+            aria-pressed={on}
+            tabIndex={-1}
+            onClick={onClick}
+            className={`shrink-0 rounded px-1 h-5 min-w-5 text-[10px] leading-none font-mono grid place-items-center transition-colors ${
+                on
+                    ? "bg-base-content/15 text-base-content"
+                    : "text-base-content/50 hover:text-base-content hover:bg-base-content/10"
+            }`}
+        >
+            {children}
+        </button>
+    );
+}
+
+function IconButton({
+    title,
+    onClick,
+    disabled,
+    children,
+}: {
+    title: string;
+    onClick: () => void;
+    disabled?: boolean;
+    children: React.ReactNode;
+}) {
+    return (
+        <button
+            type="button"
+            title={title}
+            disabled={disabled}
+            tabIndex={-1}
+            onClick={onClick}
+            className="shrink-0 rounded p-1 text-base-content/70 hover:text-base-content hover:bg-base-content/10 disabled:opacity-30 disabled:pointer-events-none"
+        >
+            {children}
+        </button>
+    );
+}
+
+export function FindBar() {
+    const storeApi = useEditorStoreApi();
+    const { textAreaDomRef } = useEditorDom();
+    const mac = useApplePlatform();
+    const { t } = useTranslation();
+
+    const search = useSearchStoreApi();
+    const findInputRef = useRef<HTMLInputElement>(null);
+
+    const open = useSearchStore((s) => s.state.open);
+    const replaceExpanded = useSearchStore((s) => s.state.replaceExpanded);
+    const query = useSearchStore((s) => s.state.query);
+    const replacement = useSearchStore((s) => s.state.replacement);
+    const caseSensitive = useSearchStore((s) => s.state.caseSensitive);
+    const wholeWord = useSearchStore((s) => s.state.wholeWord);
+    const regex = useSearchStore((s) => s.state.regex);
+    const usePreserveCase = useSearchStore((s) => s.state.preserveCase);
+    const total = useSearchStore((s) => s.state.matches.length);
+    const activeIndex = useSearchStore((s) => s.state.activeIndex);
+    const queryError = useSearchStore((s) => s.state.queryError);
+    const limitHit = useSearchStore((s) => s.state.limitHit);
+
+    // Engine wiring: attach the editor store, bind the highlight painter to
+    // the live editor DOM. Both dispose on unmount / store swap.
+    useEffect(() => {
+        if (!storeApi) return;
+        return search.attach(storeApi);
+    }, [search, storeApi]);
+
+    useEffect(() => {
+        const container = textAreaDomRef.current;
+        if (!storeApi || !container) return;
+        return bindSearchPainter(search, storeApi, container);
+    }, [search, storeApi, textAreaDomRef]);
+
+    // Focus + select the find input on every open transition. This covers
+    // both entry points (shortcut and menu) — the store owns the prefill, the
+    // UI owns the focus. Running in the effect (not rAF) keeps the focus
+    // inside the triggering gesture's task, so touch devices raise the soft
+    // keyboard.
+    useEffect(() => {
+        if (!open) return;
+        findInputRef.current?.focus();
+        findInputRef.current?.select();
+    }, [open]);
+
+    const close = () => {
+        search.close();
+        storeApi?.focus();
+    };
+
+    // Global shortcuts (capture: they must beat the browser's native find and
+    // the editor's contentEditable handlers).
+    useEffect(() => {
+        // Re-triggering while already open re-selects the input — the open
+        // effect only fires on transitions.
+        const refocus = () => {
+            findInputRef.current?.focus();
+            findInputRef.current?.select();
+        };
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.defaultPrevented) return;
+            // F3 carries no modifier discipline — it is a dedicated key.
+            if (e.key === "F3" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+                if (!search.state.open) return;
+                e.preventDefault();
+                if (e.shiftKey) search.findPrevious();
+                else search.findNext();
+                return;
+            }
+            const primary = mac ? e.metaKey : e.ctrlKey;
+            const foreign = mac ? e.ctrlKey : e.metaKey;
+            if (!primary || foreign) return;
+            if (e.code === "KeyF" && !e.shiftKey) {
+                if (mac && e.altKey) {
+                    e.preventDefault();
+                    search.openReplace();
+                    refocus();
+                    return;
+                }
+                if (!e.altKey) {
+                    e.preventDefault();
+                    search.openFind();
+                    refocus();
+                    return;
+                }
+                return;
+            }
+            if (!mac && e.code === "KeyH" && !e.altKey && !e.shiftKey) {
+                e.preventDefault();
+                search.openReplace();
+                refocus();
+                return;
+            }
+            if (mac && e.code === "KeyG" && !e.altKey) {
+                if (!search.state.open) return;
+                e.preventDefault();
+                if (e.shiftKey) search.findPrevious();
+                else search.findNext();
+            }
+        };
+        window.addEventListener("keydown", onKeyDown, true);
+        return () => window.removeEventListener("keydown", onKeyDown, true);
+    }, [mac, search]);
+
+    if (!open) return null;
+
+    const count =
+        total === 0
+            ? queryError ?? (query ? t("editor.find.noResults") : "")
+            : t("editor.find.count", {
+                  current: activeIndex + 1,
+                  total: limitHit ? `${total}+` : total,
+              });
+
+    return (
+        // Zero-height sticky layer: pins to the top of the visible document
+        // area without occupying flow; hidden in print.
+        <div className="sticky top-0 z-30 h-0 print:hidden">
+            <div
+                className="absolute right-4 top-2 rounded-lg border border-base-content/15 bg-base-200 text-base-content shadow-lg p-1 flex items-stretch select-none"
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => {
+                    if (e.key === "Escape") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        close();
+                    }
+                }}
+            >
+                <button
+                    type="button"
+                    title={t("editor.find.toggleReplace")}
+                    tabIndex={-1}
+                    onClick={() => search.toggleReplaceExpanded()}
+                    className="shrink-0 rounded px-0.5 text-base-content/50 hover:text-base-content hover:bg-base-content/10"
+                >
+                    <ChevronIcon open={replaceExpanded} />
+                </button>
+                <div className="flex flex-col gap-1 ml-1">
+                    <div className="flex items-center gap-1">
+                        <div
+                            className={`flex items-center gap-0.5 h-7 w-56 max-sm:w-36 px-1.5 rounded-md bg-base-100 border ${
+                                queryError
+                                    ? "border-error/60"
+                                    : "border-base-content/15 focus-within:border-base-content/40"
+                            }`}
+                            title={queryError ?? undefined}
+                        >
+                            <input
+                                ref={findInputRef}
+                                value={query}
+                                spellCheck={false}
+                                placeholder={t("editor.find.placeholder")}
+                                onChange={(e) =>
+                                    search.setQuery(e.target.value)
+                                }
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter") {
+                                        e.preventDefault();
+                                        if (e.shiftKey) search.findPrevious();
+                                        else search.findNext();
+                                    }
+                                }}
+                                className="min-w-0 grow bg-transparent outline-none text-xs"
+                            />
+                            <ToggleButton
+                                on={caseSensitive}
+                                title={t("editor.find.caseSensitive")}
+                                onClick={() =>
+                                    search.setOption(
+                                        "caseSensitive",
+                                        !caseSensitive,
+                                    )
+                                }
+                            >
+                                Aa
+                            </ToggleButton>
+                            <ToggleButton
+                                on={wholeWord}
+                                title={t("editor.find.wholeWord")}
+                                onClick={() =>
+                                    search.setOption("wholeWord", !wholeWord)
+                                }
+                            >
+                                <span className="underline underline-offset-2">
+                                    ab
+                                </span>
+                            </ToggleButton>
+                            <ToggleButton
+                                on={regex}
+                                title={t("editor.find.regex")}
+                                onClick={() =>
+                                    search.setOption("regex", !regex)
+                                }
+                            >
+                                .*
+                            </ToggleButton>
+                        </div>
+                        <span
+                            className={`text-[11px] min-w-16 px-0.5 whitespace-nowrap ${
+                                queryError
+                                    ? "text-error"
+                                    : "text-base-content/50"
+                            }`}
+                        >
+                            {count}
+                        </span>
+                        <IconButton
+                            title={t("editor.find.previous")}
+                            disabled={total === 0}
+                            onClick={() => search.findPrevious()}
+                        >
+                            <ArrowIcon />
+                        </IconButton>
+                        <IconButton
+                            title={t("editor.find.next")}
+                            disabled={total === 0}
+                            onClick={() => search.findNext()}
+                        >
+                            <ArrowIcon down />
+                        </IconButton>
+                        <IconButton
+                            title={t("editor.find.close")}
+                            onClick={close}
+                        >
+                            <CloseIcon />
+                        </IconButton>
+                    </div>
+                    {replaceExpanded ? (
+                        <div className="flex items-center gap-1">
+                            <div className="flex items-center gap-0.5 h-7 w-56 max-sm:w-36 px-1.5 rounded-md bg-base-100 border border-base-content/15 focus-within:border-base-content/40">
+                                <input
+                                    value={replacement}
+                                    spellCheck={false}
+                                    placeholder={t(
+                                        "editor.find.replacePlaceholder",
+                                    )}
+                                    onChange={(e) =>
+                                        search.setReplacement(e.target.value)
+                                    }
+                                    onKeyDown={(e) => {
+                                        if (e.key !== "Enter") return;
+                                        e.preventDefault();
+                                        const primary = mac
+                                            ? e.metaKey
+                                            : e.ctrlKey;
+                                        if (primary) search.replaceAll();
+                                        else search.replaceCurrent();
+                                    }}
+                                    className="min-w-0 grow bg-transparent outline-none text-xs"
+                                />
+                                <ToggleButton
+                                    on={usePreserveCase}
+                                    title={t("editor.find.preserveCase")}
+                                    onClick={() =>
+                                        search.setOption(
+                                            "preserveCase",
+                                            !usePreserveCase,
+                                        )
+                                    }
+                                >
+                                    AB
+                                </ToggleButton>
+                            </div>
+                            <IconButton
+                                title={t("editor.find.replaceOne")}
+                                disabled={total === 0}
+                                onClick={() => search.replaceCurrent()}
+                            >
+                                <ReplaceOneIcon />
+                            </IconButton>
+                            <IconButton
+                                title={t("editor.find.replaceAll")}
+                                disabled={total === 0}
+                                onClick={() => search.replaceAll()}
+                            >
+                                <ReplaceAllIcon />
+                            </IconButton>
+                        </div>
+                    ) : null}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * The ⋯ menu entry — shares the SearchStore through the provider, so it is
+ * literally the same openFind() call the keyboard shortcut makes. This is
+ * the only trigger on touch devices (no ⌘F there).
+ */
+export function FindMenuItem() {
+    const search = useSearchStoreApi();
+    const mac = useApplePlatform();
+    const { t } = useTranslation();
+    return (
+        <li>
+            <button
+                onClick={(e) => {
+                    e.currentTarget.blur();
+                    search.openFind();
+                }}
+            >
+                <span className="flex-1">{t("editor.find.menuTitle")}</span>
+                <span className="text-[10px] leading-none text-base-content/35 tabular-nums">
+                    {mac ? "⌘F" : "Ctrl+F"}
+                </span>
+            </button>
+        </li>
+    );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,9 @@
             "@do-md/core-react/style.css": [
                 "./.packages/@do-md/core/src/style.css"
             ],
+            "@do-md/search": [
+                "./.packages/@do-md/plugins/search/src"
+            ],
             "@do-md/toc": [
                 "./.packages/@do-md/plugins/toc/src"
             ],


### PR DESCRIPTION
Adds in-document find & replace — the search half of #22 (the outline half is #25).

## What

- **`@do-md/search`** (new package under `.packages/@do-md/plugins/search`, MIT, headless, React-free core): a pure matching engine with VSCode find-widget semantics, a zenith `SearchStore` driving scan/navigate/replace against the kernel's public editing surface, and CSS Custom Highlight painting of every match. React bindings (`SearchStoreProvider` / hooks) ship in the package, kernel-style.
- **Kernel**: one new read primitive, `EditorStore.resolveRanges(...ranges)` — the batch, zero-side-effect companion of `setSelection`'s offset addressing: absolute markdown ranges resolve to block coordinates `{uuid, offset}` in one `buildTopLevelSourceMap` pass, `null` per slot on failure. Highlight painting positions DOM ranges through it.
- **App**: `find-bar.tsx`, a VSCode-style widget (collapsed find row / expanded replace row) mounted as a zero-height sticky layer inside the editor scroll container, plus a "Find & replace" entry in the ⋯ menu (the only trigger on touch devices).

## Semantics

- Search space is the **markdown source** (`toMarkdown()`), the same coordinate space the replace family addresses — match ranges feed `setSelection` / `replaceRanges` / `resolveRanges` verbatim.
- VSCode matching semantics: literal escaping, case folding, whole-word via the separator table (CJK behavior matches VSCode), zero-length skip, 20k match cap with an explicit `limitHit`, regex replacement (`$1`/`$&`/`$$`, groups captured at scan time), preserve-case (aB) with the three-state heuristic.
- Navigation never moves the real selection (the active match is a decoration); the caret lands on the current match on close — VSCode's Escape behavior. `replaceAll` is a single `replaceRanges` call: one undo step, fine-grained collab ops.
- ⌘F/Ctrl+F opens (prefilled from the selection), ⌥⌘F/Ctrl+H opens with replace, Enter/⇧Enter and ⌘G/F3(+⇧) navigate, Esc closes. ⌘F intentionally shadows the browser's native find.
- Repaints ride the op stream + cursor changes + a MutationObserver fallback (mode switches rebuild every span with zero ops), rAF-coalesced; close clears highlights synchronously.

## Verification

- `sh scripts/verify-search/run.sh` — 64 assertions: full matcher semantics plus `SearchStore` driving the real headless `EditorStore` (prefill/anchoring, navigation wrap, option rescans, replace-current advance, replace-all as one undo step, preserve-case + groups end to end, external-edit rescan with keep-near, close landing the selection, `resolveMatchAnchors` against the real `resolveRanges`).
- `verify-resolve-ranges` — 122 assertions: per-case equivalence with `setSelection`, purity (no cursor events, no history, no ops), batch positions, collapsed ranges.
- Browser-verified: counts/navigation/wrap, options (case/word/regex incl. invalid-regex error), highlight painting, replace one/all with undo, preserve-case replaceAll, external-edit rescan, Esc close semantics.

Note: rebased onto main after #25 merged — conflicts in `editor.tsx` / `tsconfig.json` / the plugins README resolved (both features coexist: nested providers, both path mappings, both catalog rows); both verify suites (64 + 57) and typecheck pass on the merged result.